### PR TITLE
Revert to version of TestNG which the exit status is correct with retries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <aspectj.version>1.8.7</aspectj.version>
         <selenium.version>3.11.0</selenium.version>
         <page-component.version>1.2.2</page-component.version>
-        <testNg.version>6.14.2</testNg.version>
+        <testNg.version>6.11</testNg.version>
         <hamcrest.version>1.3</hamcrest.version>
         <jetty-server.version>9.4.3.v20170317</jetty-server.version>
         <java.mail.version>1.4.1</java.mail.version>


### PR DESCRIPTION
The PR https://github.com/cbeust/testng/pull/1579/files?utf8=%E2%9C%93&diff=split of TestNG broke the exit status with retries.  Previously, if a test initially failed but there was a retry and it was success, then the exit code would be 0.  However, after this PR in TestNG the exit code would be 2 (skipped tests.)

