### PR TITLE
Fix issues with soap request headers and page-component update

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/api/domainObjects/SoapGetHolidayDateDO.java
+++ b/automation-tests/src/main/java/com/automation/common/api/domainObjects/SoapGetHolidayDateDO.java
@@ -181,7 +181,7 @@ public class SoapGetHolidayDateDO extends ApiDomainObject {
         getClient().setParametersType(ParametersType.XML);
         getClient().setReturnType(ReturnType.SOAP);
         getClient().setCustomContentType("text/xml; charset=utf-8");
-        ApiUtils.updateForSoap(getHeaders(), "http://www.holidaywebservice.com/HolidayService_v2/GetHolidayDate");
+        ApiUtils.updateForSoap(this, "http://www.holidaywebservice.com/HolidayService_v2/GetHolidayDate");
         getResponse().theResponse = getClient().post(resourcePath, getRequest().envelope, SOAPEnvelopeResponse.class, getHeaders());
     }
 

--- a/automation-tests/src/main/java/com/automation/common/api/domainObjects/WeatherDO.java
+++ b/automation-tests/src/main/java/com/automation/common/api/domainObjects/WeatherDO.java
@@ -10,7 +10,6 @@ import com.taf.automation.ui.support.VTD_XML;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamOmitField;
-import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.NameValuePair;
 import org.apache.http.entity.StringEntity;
@@ -114,10 +113,8 @@ public class WeatherDO extends ApiDomainObject {
             throw new RuntimeException(e);
         }
 
-        List<Header> soapHeaders = new ArrayList<>();
-        ApiUtils.updateForSoap(soapHeaders, "http://ws.cdyne.com/WeatherWS/GetCityWeatherByZIP");
-
-        response.weather = getClient().post(resourcePath, entity, null, soapHeaders);
+        ApiUtils.updateForSoap(this, "http://ws.cdyne.com/WeatherWS/GetCityWeatherByZIP");
+        response.weather = getClient().post(resourcePath, entity, null, getHeaders());
     }
 
     public void validateStatus() {

--- a/taf/src/main/java/com/taf/automation/api/ApiDomainObject.java
+++ b/taf/src/main/java/com/taf/automation/api/ApiDomainObject.java
@@ -8,6 +8,7 @@ import com.taf.automation.api.converters.EnumConverter;
 import com.taf.automation.api.rest.GenericHttpResponse;
 import com.taf.automation.ui.support.Credentials;
 import com.taf.automation.ui.support.CreditCard;
+import com.taf.automation.ui.support.DataPersistenceV2;
 import com.taf.automation.ui.support.Environment;
 import com.taf.automation.ui.support.EnvironmentType;
 import com.taf.automation.ui.support.TestProperties;
@@ -34,7 +35,7 @@ import java.util.stream.Collectors;
 /**
  * The API Domain Object from which other API domain objects should be extended from
  */
-public class ApiDomainObject extends DataPersistence {
+public class ApiDomainObject extends DataPersistenceV2 {
     @Data(alias = "user-email")
     protected String loginUser;
     protected String loginPassword;
@@ -122,11 +123,34 @@ public class ApiDomainObject extends DataPersistence {
         return loginSession;
     }
 
+    public void addHeaders(List<BasicHeader> headers) {
+        if (this.headers == null) {
+            this.headers = new ArrayList<>();
+        }
+
+        this.headers.addAll(headers);
+    }
+
+    public void addHeader(BasicHeader header) {
+        if (headers == null) {
+            headers = new ArrayList<>();
+        }
+
+        this.headers.add(header);
+    }
+
+    /**
+     * Get the headers<BR>
+     * <B>Note: </B>Any modifications to this list will <B>NOT</B> affect the headers in this class
+     *
+     * @return new list of headers
+     */
     protected List<Header> getHeaders() {
         if (headers == null) {
             headers = new ArrayList<>();
         }
 
+        // This is returning a deep copy of the headers (based on testing.)
         return headers.stream().collect(Collectors.toList());
     }
 

--- a/taf/src/main/java/com/taf/automation/api/ApiUtils.java
+++ b/taf/src/main/java/com/taf/automation/api/ApiUtils.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtworks.xstream.XStream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
-import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
@@ -164,12 +163,12 @@ public class ApiUtils {
     /**
      * Add the headers for a SOAP Request
      *
-     * @param headers    - List of existing headers
-     * @param soapAction - The SOAP action to be added
+     * @param apiDomainObject - API Domain Object to update with the headers for a SOAP Request
+     * @param soapAction      - The SOAP action to be added
      */
-    public static void updateForSoap(List<Header> headers, String soapAction) {
-        headers.add(new BasicHeader("Content-Type", "text/xml; charset=utf-8"));
-        headers.add(new BasicHeader("SOAPAction", soapAction));
+    public static void updateForSoap(ApiDomainObject apiDomainObject, String soapAction) {
+        apiDomainObject.addHeader(new BasicHeader("Content-Type", "text/xml; charset=utf-8"));
+        apiDomainObject.addHeader(new BasicHeader("SOAPAction", soapAction));
     }
 
     /**

--- a/taf/src/main/java/com/taf/automation/ui/support/DataPersistenceV2.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/DataPersistenceV2.java
@@ -1,0 +1,28 @@
+package com.taf.automation.ui.support;
+
+import com.thoughtworks.xstream.XStream;
+import datainstiller.data.DataPersistence;
+
+/**
+ * The purpose of this class is to revert the removal of xml namespaces added to DataPersistence.  This was causing
+ * issues with SOAP requests that had xml namespaces.  This should not be an issue for page objects as it would be
+ * unusual to use xml namespaces (i.e. the attribute "xmlns".)
+ */
+public abstract class DataPersistenceV2 extends DataPersistence {
+    protected DataPersistenceV2() {
+        //
+    }
+
+    /**
+     * This method serializes this object to the given XML string
+     *
+     * @return XML representation of this object
+     */
+    public String toXML() {
+        String header = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\n";
+        XStream xstream = getXstream();
+        String xml = xstream.toXML(this);
+        return header + xml;
+    }
+
+}


### PR DESCRIPTION
The soap request test (**SoapHolidayTest**) was failing due to 2 issues:
1. The method **ApiDomainObject.getHeaders()** is returning a deep copy of the headers.  So, adding the headers was not being updated in **ApiDomainObject**.
1. After the page-component update to version 1.3.3, the **DataPersistence** class is removing all xml namespaces which seems to affect all SOAP requests.

I have added explicit methods to add headers and created another class to prevent the removing of all xml namespaces.