### PR TITLE
Implement BasicClock to replace deprecated SystemClock class

### DIFF
--- a/taf/src/main/java/com/taf/automation/ui/support/BasicClock.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/BasicClock.java
@@ -1,0 +1,37 @@
+package com.taf.automation.ui.support;
+
+/**
+ * Replacement for SystemClock class as this is deprecated in Selenium 3.14<BR>
+ * <B>Note: </B> This is the same code from the SystemClock class.<BR>
+ */
+public class BasicClock {
+    /**
+     * Computes a point of time in the future.
+     *
+     * @param durationInMillis The point in the future, in milliseconds relative to the {@link #now()
+     *                         current time}.
+     * @return A timestamp representing a point in the future.
+     */
+    public long laterBy(long durationInMillis) {
+        return System.currentTimeMillis() + durationInMillis;
+    }
+
+    /**
+     * Tests if a point in time occurs before the {@link #now() current time}.
+     *
+     * @param endInMillis The timestamp to check.
+     * @return Whether the given timestamp represents a point in time before the current time.
+     */
+    public boolean isNowBefore(long endInMillis) {
+        return System.currentTimeMillis() < endInMillis;
+    }
+
+    /**
+     * @return The current time in milliseconds since epoch time.
+     * @see System#currentTimeMillis()
+     */
+    public long now() {
+        return System.currentTimeMillis();
+    }
+
+}

--- a/taf/src/main/java/com/taf/automation/ui/support/DynamicElementLocator.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/DynamicElementLocator.java
@@ -6,8 +6,6 @@ import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.pagefactory.ElementLocator;
-import org.openqa.selenium.support.ui.Clock;
-import org.openqa.selenium.support.ui.SystemClock;
 
 import java.lang.reflect.Field;
 import java.util.List;
@@ -22,7 +20,7 @@ public class DynamicElementLocator implements ElementLocator {
     private final int timeOutInSeconds;
     private final boolean shouldCache;
     private final By by;
-    private final Clock clock;
+    private final BasicClock clock;
     private WebElement cachedElement;
     private List<WebElement> cachedElementList;
 
@@ -32,7 +30,7 @@ public class DynamicElementLocator implements ElementLocator {
         DynamicAnnotations annotations = new DynamicAnnotations(field, substitutions);
         shouldCache = annotations.isLookupCached();
         by = annotations.buildBy();
-        clock = new SystemClock();
+        clock = new BasicClock();
     }
 
     public WebElement findElement() {


### PR DESCRIPTION
In Selenium 3.14, the Clock interface and SystemClock class has been deprecated.