### PR TITLE
Add global encryption flag

### DIFF
--- a/taf/src/main/java/com/taf/automation/ui/support/TestProperties.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/TestProperties.java
@@ -32,6 +32,9 @@ public class TestProperties {
     @Property("always.install.drivers")
     private boolean alwaysInstallDrivers = false;
 
+    @Property("global.encryption")
+    private boolean globalEncryption = false;
+
     @Property("mail.proxy")
     private String mailProxy;
 
@@ -307,6 +310,10 @@ public class TestProperties {
 
     public boolean isAlwaysInstallDrivers() {
         return alwaysInstallDrivers;
+    }
+
+    public boolean isGlobalEncryption() {
+        return globalEncryption;
     }
 
     public String getMailProxy() {


### PR DESCRIPTION
My idea is to be able to have a global encryption flag which can be used instead of having a flag in the test data.  This could be useful where all passwords need to be encrypted.