### PR TITLE
 Alternative to WebDriverUtils.getDriverFromElement 

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/components/ImageUpload.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/components/ImageUpload.java
@@ -9,7 +9,6 @@ import org.openqa.selenium.remote.LocalFileDetector;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.remote.RemoteWebElement;
 import ui.auto.core.pagecomponent.PageComponentNoDefaultAction;
-import ui.auto.core.utils.WebDriverUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,7 +30,7 @@ public class ImageUpload extends PageComponentNoDefaultAction {
 
     @Override
     protected void init() {
-        driver = (RemoteWebDriver) WebDriverUtils.getDriverFromElement(getCoreElement());
+        driver = (RemoteWebDriver) Utils.getWebDriver(getCoreElement());
         inputUploadFile = (RemoteWebElement) driver.findElement(By.cssSelector("input[type=file]"));
     }
 

--- a/taf/src/main/java/com/taf/automation/ui/support/Utils.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/Utils.java
@@ -15,6 +15,7 @@ import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.RemoteWebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import ru.yandex.qatools.allure.Allure;
@@ -22,6 +23,7 @@ import ru.yandex.qatools.allure.events.MakeAttachmentEvent;
 import ui.auto.core.data.DataTypes;
 import ui.auto.core.pagecomponent.PageComponent;
 import ui.auto.core.utils.AjaxTriggeredAction;
+import ui.auto.core.utils.WebDriverUtils;
 
 import javax.annotation.Nullable;
 import java.lang.reflect.Method;
@@ -35,6 +37,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
 
 /**
  * Utilities mainly for UI
@@ -98,6 +101,41 @@ public class Utils {
      */
     private static WebDriver getWebDriver() {
         return TestNGBase.context().getDriver();
+    }
+
+    /**
+     * Get a WebDriver from a WebElement. This is useful in cases where you only have a WebElement but need a
+     * WebDriver to do some action.<BR>
+     * <B>Note: </B> The method WebDriverUtils.getDriverFromElement sometimes throws an exception as such it is
+     * recommended to use this method.<BR>
+     *
+     * @param element - WebElement to get the WebDriver from
+     * @return WebDriver
+     */
+    public static WebDriver getWebDriver(WebElement element) {
+        WebDriverUtils.getDriverFromElement(element);
+        WebDriver useDriver;
+        String error;
+
+        try {
+            /*
+             * Trick to get real element that can return the WebDriver.
+             * Notes:
+             * 1) If you use element directly it is a proxy and this cannot be cast to RemoteWebElement
+             * 2) If WebElement cannot be bound, then this will generate an exception
+             */
+            WebElement realElement = element.findElement(By.xpath("."));
+
+            // Get the WebDriver object from the real (bound) WebElement
+            useDriver = ((RemoteWebElement) realElement).getWrappedDriver();
+            error = "no error";
+        } catch (Exception ex) {
+            useDriver = null;
+            error = ex.getMessage();
+        }
+
+        assertThat("Could not get driver from element due to exception:  " + error, useDriver, notNullValue());
+        return useDriver;
     }
 
     /**

--- a/taf/src/main/java/com/taf/automation/ui/support/Utils.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/Utils.java
@@ -23,7 +23,6 @@ import ru.yandex.qatools.allure.events.MakeAttachmentEvent;
 import ui.auto.core.data.DataTypes;
 import ui.auto.core.pagecomponent.PageComponent;
 import ui.auto.core.utils.AjaxTriggeredAction;
-import ui.auto.core.utils.WebDriverUtils;
 
 import javax.annotation.Nullable;
 import java.lang.reflect.Method;
@@ -113,7 +112,6 @@ public class Utils {
      * @return WebDriver
      */
     public static WebDriver getWebDriver(WebElement element) {
-        WebDriverUtils.getDriverFromElement(element);
         WebDriver useDriver;
         String error;
 


### PR DESCRIPTION
For some unknown reason, WebDriverUtils.getDriverFromElement is throwing an exception about unable to cast to org.openqa.selenium.internal.WrapsDriver.  This previously did not occur.  I suspect that if the WebElement being passed does not implement the method, then this exception occurs.  So, by using RemoteWebElement which implements the method, this error should never occur.