### PR TITLE
Example using a data provider with CSV

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/domainObjects/CsvColumnMapping.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/domainObjects/CsvColumnMapping.java
@@ -1,0 +1,27 @@
+package com.automation.common.ui.app.domainObjects;
+
+import com.taf.automation.ui.support.csv.ColumnMapper;
+
+public enum CsvColumnMapping implements ColumnMapper {
+    USER("User"),
+    PASS("Pass"),
+    PLAYER("player"),
+    TEAM("team");
+
+    private String columnName;
+
+    CsvColumnMapping(String columnName) {
+        this.columnName = columnName;
+    }
+
+    @Override
+    public String getColumnName() {
+        return columnName.toUpperCase();
+    }
+
+    @Override
+    public ColumnMapper[] getValues() {
+        return values();
+    }
+
+}

--- a/automation-tests/src/main/java/com/automation/common/ui/app/domainObjects/TNHC_DO.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/domainObjects/TNHC_DO.java
@@ -1,18 +1,20 @@
 package com.automation.common.ui.app.domainObjects;
 
+import com.automation.common.ui.app.pageObjects.TNHC_LandingPage;
 import com.taf.automation.ui.support.DomainObject;
 import com.taf.automation.ui.support.TestContext;
-import com.automation.common.ui.app.pageObjects.TNHC_LandingPage;
+import com.taf.automation.ui.support.csv.CsvTestData;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.apache.commons.csv.CSVRecord;
 
 /**
  * Object to hold data for True North Hockey Canada
  */
 @XStreamAlias("true-north-hockey-canada")
 public class TNHC_DO extends DomainObject {
-    TNHC_LandingPage landing;
-    String user;
-    String pass;
+    private TNHC_LandingPage landing;
+    private String user;
+    private String pass;
 
     public TNHC_DO() {
 
@@ -42,6 +44,29 @@ public class TNHC_DO extends DomainObject {
 
     public String getPass() {
         return pass;
+    }
+
+    /**
+     * Use the CSV data to set the variables in the domain object
+     *
+     * @param csvTestData - CSV test data
+     */
+    @Override
+    public void setData(CsvTestData csvTestData) {
+        CSVRecord csv = csvTestData.getRecord();
+        if (csv == null) {
+            return;
+        }
+
+        if (csv.isMapped(CsvColumnMapping.USER.getColumnName())) {
+            user = csv.get(CsvColumnMapping.USER.getColumnName());
+        }
+
+        if (csv.isMapped(CsvColumnMapping.PASS.getColumnName())) {
+            pass = csv.get(CsvColumnMapping.PASS.getColumnName());
+        }
+
+        getLanding().setData(csvTestData);
     }
 
 }

--- a/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/TNHC_LandingPage.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/TNHC_LandingPage.java
@@ -1,12 +1,16 @@
 package com.automation.common.ui.app.pageObjects;
 
 import com.automation.common.ui.app.components.Search;
+import com.automation.common.ui.app.domainObjects.CsvColumnMapping;
 import com.taf.automation.ui.support.AliasedString;
 import com.taf.automation.ui.support.JsUtils;
 import com.taf.automation.ui.support.PageObjectV2;
 import com.taf.automation.ui.support.TestContext;
+import com.taf.automation.ui.support.csv.CsvTestData;
+import com.taf.automation.ui.support.csv.CsvUtils;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamOmitField;
+import org.apache.commons.csv.CSVRecord;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import ru.yandex.qatools.allure.annotations.Step;
@@ -19,6 +23,7 @@ import java.util.Map;
  * True North Hockey Canada Landing Page
  */
 public class TNHC_LandingPage extends PageObjectV2 {
+    @XStreamOmitField
     private Map<String, String> substitutions;
 
     @XStreamOmitField
@@ -99,9 +104,9 @@ public class TNHC_LandingPage extends PageObjectV2 {
         return player;
     }
 
+    @Step("Set Player")
     public void setPlayer() {
-        player.setValue();
-        player.validateData();
+        setElementValueV2(player);
     }
 
     public void setPlayerJS() {
@@ -141,6 +146,17 @@ public class TNHC_LandingPage extends PageObjectV2 {
 
     public void performAccessibilityTest() {
         performAccessibilityTest("True North Hockey Page");
+    }
+
+    /**
+     * Use the CSV data to set the variables in the domain object
+     *
+     * @param csvTestData - CSV test data
+     */
+    public void setData(CsvTestData csvTestData) {
+        CSVRecord csv = csvTestData.getRecord();
+        CsvUtils.setData(csv, CsvColumnMapping.PLAYER, player);
+        CsvUtils.setData(csv, CsvColumnMapping.TEAM, team);
     }
 
 }

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/CsvTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/CsvTest.java
@@ -1,0 +1,53 @@
+package com.automation.common.ui.app.tests;
+
+import com.automation.common.ui.app.domainObjects.TNHC_DO;
+import com.taf.automation.ui.support.TestProperties;
+import com.taf.automation.ui.support.csv.CsvTestData;
+import com.taf.automation.ui.support.csv.CsvUtils;
+import com.taf.automation.ui.support.testng.TestNGBase;
+import org.testng.ITestContext;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import ru.yandex.qatools.allure.annotations.Features;
+import ru.yandex.qatools.allure.annotations.Severity;
+import ru.yandex.qatools.allure.annotations.Stories;
+import ru.yandex.qatools.allure.model.SeverityLevel;
+
+import java.util.Iterator;
+
+/**
+ * Example test using a data provider that reads a csv file
+ */
+public class CsvTest extends TestNGBase {
+    private Iterator<Object[]> records;
+
+    @BeforeTest
+    public void setup(ITestContext injectedContext) {
+        String csvDataSet = CsvUtils.getCsvDataSetFromParameter(injectedContext, "csv");
+        records = CsvUtils.dataProvider(csvDataSet);
+    }
+
+    @DataProvider(name = "CSV_Data", parallel = true)
+    public Iterator<Object[]> dataProvider() {
+        return records;
+    }
+
+    @Features("TestNG")
+    @Stories("CSV Data Provider")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test(dataProvider = "CSV_Data")
+    public void runTestPermutation(CsvTestData csvTestData, ITestContext injectedContext) {
+        CsvUtils.testRunner(this, injectedContext, () -> runWrapper(csvTestData));
+    }
+
+    private void runWrapper(CsvTestData csvTestData) {
+        TNHC_DO tnhc = new TNHC_DO(getContext());
+        CsvUtils.initializeDataAndAttach(tnhc, csvTestData);
+
+        getContext().getDriver().get(TestProperties.getInstance().getURL());
+        tnhc.getLanding().setPlayer();
+        tnhc.getLanding().setTeam();
+    }
+
+}

--- a/automation-tests/src/main/resources/data/ui/test-cases.csv
+++ b/automation-tests/src/main/resources/data/ui/test-cases.csv
@@ -1,0 +1,3 @@
+USER,PASS,PLAYER,TEAM,alias-1,alias-2
+aa,aa-pass,${alias-1},t1,new-p1,
+bb,pass2,${alias-2},t2,,new-p2

--- a/automation-tests/src/main/resources/suites/UnversionedTests.xml
+++ b/automation-tests/src/main/resources/suites/UnversionedTests.xml
@@ -17,6 +17,15 @@
     </test>
 
     <!--
+    <test name="CSV Test">
+        <parameter name="csv" value="data/ui/test-cases.csv"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.CsvTest"/>
+        </classes>
+    </test>
+    -->
+
+    <!--
     <test name="Switch Dynamic Locator Test">
         <parameter name="data-set" value="data/ui/TNHC_TestData.xml"/>
         <classes>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <maven.source.plugin.version>3.0.1</maven.source.plugin.version>
         <maven.javadoc.plugin.version>3.0.1</maven.javadoc.plugin.version>
         <jexcelapi.version>2.6.12</jexcelapi.version>
+        <commons.csv.version>1.6</commons.csv.version>
     </properties>
 
     <build>

--- a/taf/pom.xml
+++ b/taf/pom.xml
@@ -193,6 +193,11 @@
             <artifactId>mssql-jdbc</artifactId>
             <version>${sql.server.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>${commons.csv.version}</version>
+        </dependency>
 
         <!-- START:  BDD specific dependencies -->
         <dependency>

--- a/taf/src/main/java/com/taf/automation/ui/support/DomainObject.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/DomainObject.java
@@ -1,5 +1,6 @@
 package com.taf.automation.ui.support;
 
+import com.taf.automation.ui.support.csv.CsvTestData;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.annotations.XStreamOmitField;
 import datainstiller.data.DataAliases;
@@ -144,6 +145,15 @@ public class DomainObject extends DataPersistence {
     @Override
     public void generate() {
         System.out.println(generateXML());
+    }
+
+    /**
+     * Use the CSV data to set the variables in the domain object
+     *
+     * @param csvTestData - CSV test data
+     */
+    public void setData(CsvTestData csvTestData) {
+        // Method should be overridden in extending classes
     }
 
 }

--- a/taf/src/main/java/com/taf/automation/ui/support/csv/ColumnMapper.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/csv/ColumnMapper.java
@@ -1,0 +1,109 @@
+package com.taf.automation.ui.support.csv;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The enumerations for CSV column mapping need to implement this interface.  The reason for this is enumerations
+ * cannot inherit from other enumerations, this somewhat works around the limitation.
+ */
+public interface ColumnMapper {
+    /**
+     * Get the Column Name
+     *
+     * @return String
+     */
+    String getColumnName();
+
+    /**
+     * Get the enum values<BR>
+     * <B>Note to Coder: </B> Use values() which is available in an enum
+     *
+     * @return ColumnMapper[]
+     */
+    ColumnMapper[] getValues();
+
+    /**
+     * Convert string value to enum
+     *
+     * @param columnName - Column Name
+     * @return null if no matching enum else ColumnMapper
+     */
+    default ColumnMapper toEnum(String columnName) {
+        return toEnum(getValues(), columnName);
+    }
+
+    /**
+     * Convert string value to enum
+     *
+     * @param values     - Values to used for matching
+     * @param columnName - Column Name
+     * @return null if no matching enum else ColumnMapper
+     */
+    default ColumnMapper toEnum(ColumnMapper[] values, String columnName) {
+        if (StringUtils.trimToNull(columnName) == null) {
+            return null;
+        }
+
+        for (ColumnMapper value : values) {
+            if (StringUtils.equalsIgnoreCase(StringUtils.trim(columnName), value.getColumnName())) {
+                return value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * This is debugging method to get all duplicates which can be useful as all CSV headers need to unique
+     *
+     * @return List of duplicates
+     */
+    default List<ColumnMapper> getDuplicates() {
+        Map<String, List<ColumnMapper>> columnMap = new HashMap<>();
+        for (ColumnMapper value : getValues()) {
+            String key = value.getColumnName().toUpperCase();
+            if (columnMap.containsKey(key)) {
+                List<ColumnMapper> duplicateList = columnMap.get(key);
+                duplicateList.add(value);
+                columnMap.put(key, duplicateList);
+            } else {
+                List<ColumnMapper> startList = new ArrayList<>();
+                startList.add(value);
+                columnMap.put(key, startList);
+            }
+        }
+
+        List<ColumnMapper> duplicates = new ArrayList<>();
+        for (Map.Entry<String, List<ColumnMapper>> item : columnMap.entrySet()) {
+            List<ColumnMapper> stored = item.getValue();
+            if (stored.size() > 1) {
+                duplicates.addAll(stored);
+            }
+        }
+
+        return duplicates;
+    }
+
+    /**
+     * This is a debugging method to check if the column name is unique which can be useful when adding a new column
+     * name and you need to ensure that it is unique
+     *
+     * @param columnName - Column Name to check
+     * @return true the column name is unique, false the column name already exists
+     */
+    default boolean isUnique(String columnName) {
+        for (ColumnMapper value : getValues()) {
+            if (StringUtils.equalsIgnoreCase(value.getColumnName(), columnName)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+}

--- a/taf/src/main/java/com/taf/automation/ui/support/csv/CsvTestData.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/csv/CsvTestData.java
@@ -1,0 +1,46 @@
+package com.taf.automation.ui.support.csv;
+
+import org.apache.commons.csv.CSVRecord;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class is specific for data providers for GUI that use a CSV file to hold all the tests
+ */
+public class CsvTestData {
+    private CSVRecord record;
+    private Map<String, Integer> aliases;
+
+    public CsvTestData() {
+        //
+    }
+
+    public CsvTestData(CSVRecord record, Map<String, Integer> aliases) {
+        setRecord(record);
+        getAliases().putAll(aliases);
+    }
+
+    public CSVRecord getRecord() {
+        return record;
+    }
+
+    public void setRecord(CSVRecord record) {
+        this.record = record;
+    }
+
+    public Map<String, Integer> getAliases() {
+        if (aliases == null) {
+            aliases = new HashMap<>();
+        }
+
+        return aliases;
+    }
+
+    @Override
+    public String toString() {
+        String recordNumber = (getRecord() == null) ? "null" : String.valueOf(getRecord().getRecordNumber());
+        return "Record Number=" + recordNumber;
+    }
+
+}

--- a/taf/src/main/java/com/taf/automation/ui/support/csv/CsvUtils.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/csv/CsvUtils.java
@@ -1,0 +1,210 @@
+package com.taf.automation.ui.support.csv;
+
+import com.taf.automation.ui.support.DomainObject;
+import com.taf.automation.ui.support.testng.TestNGBaseWithoutListeners;
+import datainstiller.data.DataAliases;
+import datainstiller.data.DataPersistence;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.testng.ITestContext;
+import ru.yandex.qatools.allure.Allure;
+import ru.yandex.qatools.allure.events.MakeAttachmentEvent;
+import ui.auto.core.context.PageComponentContext;
+import ui.auto.core.data.DataTypes;
+import ui.auto.core.pagecomponent.PageComponent;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * CSV utilities
+ */
+public class CsvUtils {
+    private static final String ALIAS_PREFIX = "alias-";
+
+    private CsvUtils() {
+        // Prevent initialization of class as all public methods should be static
+    }
+
+    /**
+     * Get CSV records from the specified resource and update the records parameter and headers parameter
+     *
+     * @param resourceFilePath - Resource File Path to the CSV file to read
+     * @param records          - Updated with the CSV records
+     * @param headers          - Updated with the CSV header record
+     */
+    public static void read(String resourceFilePath, List<CSVRecord> records, Map<String, Integer> headers) {
+        try {
+            InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(resourceFilePath);
+            InputStreamReader reader = new InputStreamReader(in);
+            CSVFormat csvFileFormat = CSVFormat.EXCEL.withHeader();
+            CSVParser csvFileParser = new CSVParser(reader, csvFileFormat);
+            headers.putAll(csvFileParser.getHeaderMap());
+            records.addAll(csvFileParser.getRecords());
+        } catch (Exception ex) {
+            assertThat("Could not read records from CSV file due to error:  " + ex.getMessage(), false);
+        }
+    }
+
+    /**
+     * Get all the aliases from the CSV header row
+     *
+     * @param headers - CSV Headers to check for aliases
+     * @return Map of aliases
+     */
+    public static Map<String, Integer> getAliasHeaders(Map<String, Integer> headers) {
+        Map<String, Integer> aliasMap = new HashMap<>();
+
+        for (Map.Entry<String, Integer> item : headers.entrySet()) {
+            if (StringUtils.startsWithIgnoreCase(item.getKey(), ALIAS_PREFIX)) {
+                aliasMap.put(item.getKey(), item.getValue());
+            }
+        }
+
+        return aliasMap;
+    }
+
+    /**
+     * Update aliases<BR>
+     * <B>Note: </B> Domain Object can be set to null to skip updating it
+     *
+     * @param domainObject - Domain Object to update aliases just for reporting
+     * @param csvTestData  - CSV test data
+     */
+    public static void updateAliases(DomainObject domainObject, CsvTestData csvTestData) {
+        if (domainObject != null && domainObject.getDataAliases() == null) {
+            try {
+                FieldUtils.writeField(domainObject, "aliases", new DataAliases(), true);
+            } catch (Exception ex) {
+                assertThat("Unable to initialize the variable aliases", false);
+            }
+        }
+
+        for (Map.Entry<String, Integer> item : csvTestData.getAliases().entrySet()) {
+            String aliasKey = item.getKey();
+            String aliasValue = csvTestData.getRecord().get(aliasKey);
+            PageComponentContext.getGlobalAliases().put(aliasKey, aliasValue);
+
+            // Add to domain object such that data is in the report
+            if (domainObject != null) {
+                domainObject.getDataAliases().put(aliasKey, aliasValue);
+            }
+        }
+    }
+
+    /**
+     * Attach Data Set to the allure report
+     *
+     * @param data - Data to be attached to the report
+     */
+    public static void attachDataSet(DataPersistence data) {
+        byte[] attachment = data.toXML().getBytes();
+        MakeAttachmentEvent ev = new MakeAttachmentEvent(attachment, "Test Data", "text/xml");
+        Allure.LIFECYCLE.fire(ev);
+    }
+
+    /**
+     * Use the CSV data to set the variables in the domain object<BR>
+     * <B>Note: </B> Initial &amp; Expected data is not changed<BR>
+     *
+     * @param csv       - CSV record data
+     * @param column    - Column Enumeration that maps to component
+     * @param component - Component to initialize data
+     */
+    public static void setData(CSVRecord csv, ColumnMapper column, PageComponent component) {
+        if (csv.isMapped(column.getColumnName())) {
+            String initial = component.getData(DataTypes.Initial, false);
+            String expected = component.getData(DataTypes.Expected, false);
+            component.initializeData(csv.get(column.getColumnName()), initial, expected);
+        }
+    }
+
+    /**
+     * Get CSV Data Set (resource) location from parameter (in the suite file)
+     *
+     * @param testNGContext - TestNG Context
+     * @param parameter     - Parameter that contains the CSV Data Set (resource) location
+     * @return CSV Data Set (resource) location
+     */
+    public static String getCsvDataSetFromParameter(ITestContext testNGContext, String parameter) {
+        String csvDataSet = testNGContext.getCurrentXmlTest().getParameter(parameter);
+        String reason = "Parameter '" + parameter + "' missing for test:  " + testNGContext.getName();
+        assertThat(reason, csvDataSet, not(isEmptyOrNullString()));
+        return csvDataSet;
+    }
+
+    /**
+     * Generic Data Provider for CSV files<BR>
+     * <B>Note: </B> It is recommended to call this method in the BeforeTest annotation such that any error with fail
+     * the test.  Any failure in the DataProvider annotation will just mark the test as skipped and you could have
+     * a successful test run.
+     *
+     * @param csvDataSet - CSV Data Set (resource) location
+     * @return Iterator&lt;Object[]&gt;
+     */
+    public static Iterator<Object[]> dataProvider(String csvDataSet) {
+        List<Object[]> tests = new ArrayList<>();
+
+        List<CSVRecord> records = new ArrayList<>();
+        Map<String, Integer> headers = new HashMap<>();
+        CsvUtils.read(csvDataSet, records, headers);
+        Map<String, Integer> aliases = CsvUtils.getAliasHeaders(headers);
+
+        for (CSVRecord record : records) {
+            tests.add(new Object[]{new CsvTestData(record, aliases)});
+        }
+
+        return tests.iterator();
+    }
+
+    /**
+     * Generic Test Runner
+     *
+     * @param testNGContext - TestNG Context
+     * @param testClass     - Test Class to be run
+     * @param testActions   - Lambda expression to run all test steps/actions
+     */
+    public static void testRunner(
+            TestNGBaseWithoutListeners testClass,
+            ITestContext testNGContext,
+            final Runnable testActions
+    ) {
+        try {
+            // When using the data provider functionality, this method needs to be called in this new thread
+            testClass.initTest(testNGContext);
+
+            // Put all normal test actions in another method such that Sonar Cognitive Complexity violation
+            // does not occur.
+            testActions.run();
+        } finally {
+            // When using the data provider functionality, this method needs to be called in this new thread
+            // as TestNG does not call this method.
+            testClass.closeDriver();
+        }
+    }
+
+    /**
+     * Generic method to initialize the data (including aliases) and attach the data to the report
+     *
+     * @param domainObject - Domain Object to initialize with specified data
+     * @param csvTestData  - CSV Test Data to be used
+     */
+    public static void initializeDataAndAttach(DomainObject domainObject, CsvTestData csvTestData) {
+        domainObject.setData(csvTestData);
+        updateAliases(domainObject, csvTestData);
+        attachDataSet(domainObject);
+    }
+
+}


### PR DESCRIPTION
This is a use case in which you are given a flat file that contains various permutations of the test to be run.  If you forced to use a flat file instead of structured file, then this is the necessary work to be done for every test that uses a flat file.

I have tried to make it generic as possible.  However, mapping the flat file to objects cannot be done generically.