### PR TITLE
Add support of lists in csv files

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/domainObjects/CSV_DO.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/domainObjects/CSV_DO.java
@@ -1,0 +1,87 @@
+package com.automation.common.ui.app.domainObjects;
+
+import com.automation.common.ui.app.pageObjects.FakeLoginPage;
+import com.taf.automation.ui.support.DomainObject;
+import com.taf.automation.ui.support.TestContext;
+import com.taf.automation.ui.support.csv.CsvTestData;
+import com.taf.automation.ui.support.csv.CsvUtils;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.apache.commons.csv.CSVRecord;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Object to hold data for CSV testing
+ */
+@XStreamAlias("csv-do")
+public class CSV_DO extends DomainObject {
+    private List<FakeLoginPage> userLogins;
+    private List<FakeLoginPage> adminLogins;
+
+    public CSV_DO() {
+        super();
+    }
+
+    public CSV_DO(TestContext context) {
+        super(context);
+    }
+
+    public List<FakeLoginPage> getUserLogins() {
+        if (userLogins == null) {
+            userLogins = new ArrayList<>();
+        }
+
+        for (FakeLoginPage item : userLogins) {
+            if (item.getContext() == null) {
+                item.initPage(getContext());
+            }
+        }
+
+        return userLogins;
+    }
+
+    public List<FakeLoginPage> getAdminLogins() {
+        if (adminLogins == null) {
+            adminLogins = new ArrayList<>();
+        }
+
+        for (FakeLoginPage item : adminLogins) {
+            if (item.getContext() == null) {
+                item.initPage(getContext());
+            }
+        }
+
+        return adminLogins;
+    }
+
+    /**
+     * Use the CSV data to set the variables in the domain object
+     *
+     * @param csvTestData - CSV test data
+     */
+    @Override
+    public void setData(CsvTestData csvTestData) {
+        CSVRecord csv = csvTestData.getRecord();
+        if (csv == null) {
+            return;
+        }
+
+        int size = CsvUtils.getListSize(csv, CsvColumnMapping.USER_LOGINS_EMAIL, CsvColumnMapping.USER_LOGINS_PASSWORD);
+        userLogins = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            FakeLoginPage item = new FakeLoginPage(getContext());
+            item.setData(csvTestData, i, true);
+            userLogins.add(item);
+        }
+
+        size = CsvUtils.getListSize(csv, CsvColumnMapping.ADMIN_LOGINS_EMAIL, CsvColumnMapping.ADMIN_LOGINS_PASSWORD);
+        adminLogins = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            FakeLoginPage item = new FakeLoginPage(getContext());
+            item.setData(csvTestData, i, false);
+            adminLogins.add(item);
+        }
+    }
+
+}

--- a/automation-tests/src/main/java/com/automation/common/ui/app/domainObjects/CsvColumnMapping.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/domainObjects/CsvColumnMapping.java
@@ -7,7 +7,13 @@ public enum CsvColumnMapping implements ColumnMapper {
     USER("USER"),
     PASS("PASS"),
     PLAYER("player"),
-    TEAM("Team");
+    TEAM("Team"),
+
+    DESCRIPTION("Description"),
+    USER_LOGINS_EMAIL("user-logins-email"),
+    USER_LOGINS_PASSWORD("user-logins-password"),
+    ADMIN_LOGINS_EMAIL("admin-logins-email"),
+    ADMIN_LOGINS_PASSWORD("admin-logins-password");
 
     private String columnName;
 

--- a/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/FakeLoginPage.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/FakeLoginPage.java
@@ -1,0 +1,57 @@
+package com.automation.common.ui.app.pageObjects;
+
+import com.automation.common.ui.app.components.TextBox;
+import com.automation.common.ui.app.domainObjects.CsvColumnMapping;
+import com.taf.automation.ui.support.PageObjectV2;
+import com.taf.automation.ui.support.TestContext;
+import com.taf.automation.ui.support.csv.CsvTestData;
+import com.taf.automation.ui.support.csv.CsvUtils;
+import org.apache.commons.csv.CSVRecord;
+import org.openqa.selenium.support.FindBy;
+import ui.auto.core.data.DataTypes;
+
+/**
+ * This is a fake login page used to test CSV with list objects
+ */
+public class FakeLoginPage extends PageObjectV2 {
+    @FindBy(id = "email")
+    private TextBox email;
+
+    @FindBy(id = "password")
+    private TextBox password;
+
+    public FakeLoginPage() {
+        super();
+    }
+
+    public FakeLoginPage(TestContext context) {
+        super(context);
+    }
+
+    public String getEmailData() {
+        return email.getData(DataTypes.Data, true);
+    }
+
+    public String getPasswordData() {
+        return password.getData(DataTypes.Data, true);
+    }
+
+    /**
+     * Use the CSV data to set the variables in the domain object
+     *
+     * @param csvTestData - CSV test data
+     * @param index       - Index of list item
+     * @param user        - true if setting user login, false for setting admin login
+     */
+    public void setData(CsvTestData csvTestData, int index, boolean user) {
+        CSVRecord csv = csvTestData.getRecord();
+        if (user) {
+            CsvUtils.setData(csv, CsvColumnMapping.USER_LOGINS_EMAIL, index, email);
+            CsvUtils.setData(csv, CsvColumnMapping.USER_LOGINS_PASSWORD, index, password);
+        } else {
+            CsvUtils.setData(csv, CsvColumnMapping.ADMIN_LOGINS_EMAIL, index, email);
+            CsvUtils.setData(csv, CsvColumnMapping.ADMIN_LOGINS_PASSWORD, index, password);
+        }
+    }
+
+}

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/CsvListTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/CsvListTest.java
@@ -1,0 +1,80 @@
+package com.automation.common.ui.app.tests;
+
+import com.automation.common.ui.app.domainObjects.CSV_DO;
+import com.automation.common.ui.app.domainObjects.CsvColumnMapping;
+import com.automation.common.ui.app.pageObjects.FakeLoginPage;
+import com.taf.automation.ui.support.csv.CsvTestData;
+import com.taf.automation.ui.support.csv.CsvUtils;
+import com.taf.automation.ui.support.testng.TestNGBase;
+import org.testng.ITestContext;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import ru.yandex.qatools.allure.annotations.Features;
+import ru.yandex.qatools.allure.annotations.Severity;
+import ru.yandex.qatools.allure.annotations.Step;
+import ru.yandex.qatools.allure.annotations.Stories;
+import ru.yandex.qatools.allure.model.SeverityLevel;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Example test using a data provider that reads a csv file with lists
+ */
+public class CsvListTest extends TestNGBase {
+    private Iterator<Object[]> records;
+
+    @BeforeTest
+    public void setup(ITestContext injectedContext) {
+        String csvDataSet = CsvUtils.getCsvDataSetFromParameter(injectedContext, "csv");
+        records = CsvUtils.dataProvider(csvDataSet, CsvColumnMapping.RUN.getColumnName()).iterator();
+    }
+
+    @DataProvider(name = "CSV_Data", parallel = true)
+    public Iterator<Object[]> dataProvider() {
+        return records;
+    }
+
+    @Features("TestNG")
+    @Stories("CSV Data Provider")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test(dataProvider = "CSV_Data")
+    public void runTestPermutation(CsvTestData csvTestData, ITestContext injectedContext) {
+        CsvUtils.testRunner(this, injectedContext, () -> runWrapper(csvTestData));
+    }
+
+    private void runWrapper(CsvTestData csvTestData) {
+        CSV_DO csvDO = new CSV_DO(getContext());
+        CsvUtils.initializeDataAndAttach(csvDO, csvTestData);
+        String description = csvTestData.getRecord().get(CsvColumnMapping.DESCRIPTION.getColumnName());
+        output(description, csvDO);
+    }
+
+    @Step("Test Description:  {0}")
+    private void output(String description, CSV_DO csvDO) {
+        List<FakeLoginPage> users = csvDO.getUserLogins();
+        List<FakeLoginPage> admins = csvDO.getAdminLogins();
+
+        output("Users List", users.size());
+        for (FakeLoginPage item : users) {
+            output(item.getEmailData(), item.getPasswordData());
+        }
+
+        output("Admins List", admins.size());
+        for (FakeLoginPage item : admins) {
+            output(item.getEmailData(), item.getPasswordData());
+        }
+    }
+
+    @Step("{0} had size of {1}")
+    private void output(String listName, int size) {
+        //
+    }
+
+    @Step("Email={0}; Password={1}")
+    private void output(String email, String password) {
+        //
+    }
+
+}

--- a/automation-tests/src/main/resources/data/ui/list-testing.csv
+++ b/automation-tests/src/main/resources/data/ui/list-testing.csv
@@ -1,0 +1,9 @@
+RUN,Description,user-logins-email-list-0,user-logins-password-list-0,user-logins-email-list-1,user-logins-password-list-1,admin-logins-email-list-0,admin-logins-password-list-0,admin-logins-email-list-1,admin-logins-password-list-1,alias-1,alias-2
+y,Only single user login,aaa,aaa-pass,,,,,,,,
+y,No logins as item 0 is empty,,,bbb,bbb-pass,,,,,,
+y,Only single admin login,,,,,ccc,ccc-pass,,,,
+y,No logins as item 0 is empty,,,,,,,ddd,ddd-pass,,
+y,One of each login,eee,eee-pass,,,fff,fff-pass,,,,
+y,Multiple of each login,ggg,ggg-pass,hhh,hhh-pass,iii,iii-pass,jjj,jjj-pass,,
+y,Uneven logins,kkk,kkk-pass,mmm,mmm-pass,nnn,nnn-pass,,,,
+y,Logins with aliases,${alias-1},${alias-2},,,,,,,ppp,ppp-pass

--- a/automation-tests/src/main/resources/suites/UnversionedTests.xml
+++ b/automation-tests/src/main/resources/suites/UnversionedTests.xml
@@ -17,6 +17,15 @@
     </test>
 
     <!--
+    <test name="CSV List Test">
+        <parameter name="csv" value="data/ui/list-testing.csv"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.CsvListTest"/>
+        </classes>
+    </test>
+    -->
+
+    <!--
     <test name="Masking Test">
         <parameter name="file" value="data/ui/testingExcel.xls"/>
         <parameter name="extension" value=".xls"/>

--- a/taf/src/main/java/com/taf/automation/ui/support/csv/CsvUtils.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/csv/CsvUtils.java
@@ -50,6 +50,7 @@ import static org.hamcrest.Matchers.not;
  */
 public class CsvUtils {
     private static final String ALIAS_PREFIX = "alias-";
+    private static final String LIST_SUFFIX = "-list-";
 
     private CsvUtils() {
         // Prevent initialization of class as all public methods should be static
@@ -186,6 +187,24 @@ public class CsvUtils {
             String initial = component.getData(DataTypes.Initial, false);
             String expected = component.getData(DataTypes.Expected, false);
             component.initializeData(csv.get(column.getColumnName()), initial, expected);
+        }
+    }
+
+    /**
+     * Use the CSV data to set the list data for a component<BR>
+     * <B>Note: </B> Initial &amp; Expected data is not changed<BR>
+     *
+     * @param csv       - CSV record data
+     * @param column    - Column Enumeration that maps to component
+     * @param index     - Index used to construct the list column name to get the data
+     * @param component - Component to initialize data
+     */
+    public static void setData(CSVRecord csv, ColumnMapper column, int index, PageComponent component) {
+        String listColumnName = column.getColumnName() + LIST_SUFFIX + index;
+        if (csv.isMapped(listColumnName)) {
+            String initial = component.getData(DataTypes.Initial, false);
+            String expected = component.getData(DataTypes.Expected, false);
+            component.initializeData(csv.get(listColumnName), initial, expected);
         }
     }
 
@@ -381,6 +400,59 @@ public class CsvUtils {
         }
 
         return false;
+    }
+
+    /**
+     * Check if the column of a list item is mapped and there is non-blank data<BR>
+     * <B>Note: </B> The LIST_SUFFIX is appended plus the index value to the column name
+     *
+     * @param csv    - CSV record data
+     * @param index  - Index of the item to check
+     * @param column - Column Enumeration to check if it is mapped and there is non-blank data
+     * @return true if the column of the specified list item is mapped and there is non-blank data
+     */
+    public static boolean isNotBlank(CSVRecord csv, int index, ColumnMapper column) {
+        String listColumnName = column.getColumnName() + LIST_SUFFIX + index;
+        return csv.isMapped(listColumnName) && StringUtils.isNotBlank(csv.get(listColumnName));
+    }
+
+    /**
+     * Check if any of the columns for the list item is mapped and there is non-blank data<BR>
+     * <B>Note: </B> The LIST_SUFFIX is appended plus the index value to the column name
+     *
+     * @param csv     - CSV record data
+     * @param index   - Index of the item to check
+     * @param columns - Column Enumerations to check if any are mapped and there is corresponding non-blank data
+     * @return true if any column of the specified list item is mapped and there is corresponding non-blank data
+     */
+    public static boolean isAnyNotBlank(CSVRecord csv, int index, ColumnMapper... columns) {
+        if (columns == null) {
+            return false;
+        }
+
+        for (ColumnMapper column : columns) {
+            if (isNotBlank(csv, index, column)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the list size
+     *
+     * @param csv     - CSV record data
+     * @param columns - Column Enumerations of the list to check if any are mapped and there is corresponding non-blank data
+     * @return the list size
+     */
+    public static int getListSize(CSVRecord csv, ColumnMapper... columns) {
+        int size = 0;
+        while (isAnyNotBlank(csv, size, columns)) {
+            size++;
+        }
+
+        return size;
     }
 
     /**


### PR DESCRIPTION
The naming convention for the CSV header columns for lists needs to be the following to be found:
**Column Name + List Suffix + Index**

In the CsvColumnMapping enumeration, only put the base column names of the Object as the CSV Utilities method will construct the expected mapping based on passed index to get the specific list item.
