### PR TITLE
Fix to SelectEnhanced such that the component can be re-used when re-initializing the data

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/components/SelectEnhanced.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/components/SelectEnhanced.java
@@ -192,6 +192,12 @@ public class SelectEnhanced extends PageComponent {
     }
 
     @Override
+    public void initializeData(String data, String initialData, String expectedData) {
+        selection = null;  // Trigger parsing and initialization
+        super.initializeData(data, initialData, expectedData);
+    }
+
+    @Override
     public void setValue() {
         Failsafe.with(Utils.getPollingRetryPolicy()).run(this::setValueAttempt);
     }


### PR DESCRIPTION
This component has special parsing that is done only once.  It is necessary to reset the flag such that the parsing can be done again when the data is re-initialized.