### PR TITLE
Add loading Excel file from resource with fallback to absolute location

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <maven.javadoc.plugin.version>3.0.1</maven.javadoc.plugin.version>
         <jexcelapi.version>2.6.12</jexcelapi.version>
         <commons.csv.version>1.6</commons.csv.version>
+        <fillo.version>1.18</fillo.version>
     </properties>
 
     <build>

--- a/taf/pom.xml
+++ b/taf/pom.xml
@@ -198,6 +198,11 @@
             <artifactId>commons-csv</artifactId>
             <version>${commons.csv.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.codoid.products</groupId>
+            <artifactId>fillo</artifactId>
+            <version>${fillo.version}</version>
+        </dependency>
 
         <!-- START:  BDD specific dependencies -->
         <dependency>

--- a/taf/src/main/java/com/taf/automation/ui/support/FilloUtils.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/FilloUtils.java
@@ -1,0 +1,99 @@
+package com.taf.automation.ui.support;
+
+import com.codoid.products.fillo.Connection;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.openxml4j.opc.OPCPackage;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.net.URL;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Utilities for Fillo library
+ */
+public class FilloUtils {
+    private FilloUtils() {
+        // Prevent initialization of class as all public methods should be static
+    }
+
+    /**
+     * Get Connection to Excel file
+     *
+     * @param resourceFilePath - Resource File Path (or actual file system path) to the Excel file to read
+     * @return Connection
+     */
+    public static Connection getConnection(String resourceFilePath) {
+        Connection connection;
+
+        try {
+            FileInputStream file = openFileInputStream(resourceFilePath);
+            assertThat("Could not open stream - " + resourceFilePath, file, notNullValue());
+
+            Workbook workbook = getWorkbook(file, resourceFilePath);
+            assertThat("Unable to connect workbook - " + resourceFilePath, workbook, notNullValue());
+
+            connection = new Connection(workbook, file, resourceFilePath, true);
+        } catch (Exception ignore) {
+            connection = null;
+        }
+
+        assertThat("Workbook is not found - " + resourceFilePath, connection, notNullValue());
+        return connection;
+    }
+
+    /**
+     * Open FileInputStream from resource file and if that fails try from the actual file system
+     *
+     * @param resourceFilePath - Resource File Path (or actual file system path) to the excel file to read
+     * @return null if cannot open else FileInputStream
+     */
+    private static FileInputStream openFileInputStream(String resourceFilePath) {
+        FileInputStream fileInputStream = null;
+
+        URL url = Thread.currentThread().getContextClassLoader().getResource(resourceFilePath);
+        if (url == null) {
+            try {
+                fileInputStream = new FileInputStream(resourceFilePath);
+            } catch (Exception ex) {
+                //
+            }
+        } else {
+            try {
+                File file = new File(url.toURI());
+                fileInputStream = new FileInputStream(file);
+            } catch (Exception ex) {
+                //
+            }
+        }
+
+        return fileInputStream;
+    }
+
+    private static Workbook getWorkbook(InputStream in, String filePath) {
+        Workbook workbook;
+
+        try {
+            if (FilenameUtils.getExtension(filePath).equalsIgnoreCase("XLS")) {
+                workbook = new HSSFWorkbook(in);
+            } else if (FilenameUtils.getExtension(filePath).equalsIgnoreCase("XLSX")) {
+                workbook = new XSSFWorkbook(in);
+            } else if (FilenameUtils.getExtension(filePath).equalsIgnoreCase("XLSM")) {
+                workbook = new XSSFWorkbook(OPCPackage.open(in));
+            } else {
+                workbook = null;
+            }
+        } catch (Exception ignore) {
+            workbook = null;
+        }
+
+        return workbook;
+    }
+
+}

--- a/taf/src/main/java/com/taf/automation/ui/support/JsUtils.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/JsUtils.java
@@ -15,7 +15,7 @@ import org.openqa.selenium.support.ui.WebDriverWait;
  * This class provides utility methods to work with JavaScript
  */
 public class JsUtils {
-    private static final String ID = "id";
+    public static final String ID = "id";
     private static final String SCROLL_INTO_VIEW_WITH_OFFSET = Utils.readResource("JS/ScrollIntoViewWithOffset.js");
     private static final String FOCUS = Utils.readResource("JS/Focus.js");
     private static final String GET_TEXT_ONLY_TOP_LEVEL = Utils.readResource("JS/GetTextOnlyTopLevel.js");


### PR DESCRIPTION
A draw back of using the Fillo library is that it only supports a single way to get a connection which is by absolute location of the file.  This PR implements a getConnection method based in the same method in the Fillio class except it supports resources and absolute locations.  Also, if necessary in the future, it is straight forward to implement other connection methods.