### PR TITLE
Store base path to support endpoints in which the environment is in the path

### DIFF
--- a/taf/src/main/java/com/taf/automation/api/clients/ApiClient.java
+++ b/taf/src/main/java/com/taf/automation/api/clients/ApiClient.java
@@ -10,6 +10,7 @@ import com.taf.automation.api.rest.GenericHttpInterface;
 import com.taf.automation.api.rest.GenericHttpResponse;
 import com.taf.automation.ui.support.CryptoUtils;
 import com.taf.automation.ui.support.TestProperties;
+import com.taf.automation.ui.support.URLUtils;
 import com.thoughtworks.xstream.XStream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;
@@ -31,6 +32,7 @@ import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
@@ -55,6 +57,7 @@ public class ApiClient implements GenericHttpInterface {
     private static final String ACCEPT = "Accept";
     private static final String CONTENT_TYPE = "Content-type";
     private CloseableHttpClient client;
+    private String basePath;
     private HttpHost targetHost;
     private HttpClientContext clientContext;
     private ParametersType parametersType;
@@ -132,7 +135,10 @@ public class ApiClient implements GenericHttpInterface {
             int socketTimeout,
             int connectionTimeout
     ) {
-        targetHost = getTargetHost(url);
+        // The target host does not allow a path value.  So, we will extract the path from the url and store for later.
+        URIBuilder uri = URLUtils.getURI(url);
+        basePath = uri.getPath();
+        targetHost = getTargetHost(StringUtils.removeEnd(url, uri.getPath()));
         client = buildClient(socketTimeout, connectionTimeout);
         clientContext = buildClientContext(targetHost, user, password);
         this.parametersType = parametersType;
@@ -365,6 +371,10 @@ public class ApiClient implements GenericHttpInterface {
 
     public void setXstream(XStream xstream) {
         this.xstream = xstream;
+    }
+
+    public String getBasePath() {
+        return basePath;
     }
 
     @Override


### PR DESCRIPTION
The target host cannot contain a path.  However, some endpoints may contain environment in the path.  So, I will parse the URL and store the base path and set the target host without the base path.  Later, the user will be able to construct the resource path including the stored based path if necessary.