### PR TITLE
Re-factor to attach response before attempting to parse

### DIFF
--- a/taf/src/main/java/com/taf/automation/api/clients/GenericResponse.java
+++ b/taf/src/main/java/com/taf/automation/api/clients/GenericResponse.java
@@ -1,14 +1,13 @@
 package com.taf.automation.api.clients;
 
+import com.taf.automation.api.ApiUtils;
+import com.taf.automation.api.rest.GenericBaseError;
+import com.taf.automation.api.rest.GenericHttpResponse;
+import com.taf.automation.api.rest.TextError;
 import org.apache.http.Header;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.util.EntityUtils;
-
-import com.taf.automation.api.rest.GenericBaseError;
-import com.taf.automation.api.rest.GenericHttpResponse;
-import com.taf.automation.api.rest.TextError;
-import com.taf.automation.api.ApiUtils;
 
 /**
  * Generic Response
@@ -39,17 +38,14 @@ public class GenericResponse<T> implements GenericHttpResponse<T> {
 
         try {
             entityAsString = EntityUtils.toString(response.getEntity());
-            String attachName = "RESPONSE ENTITY";
+            ApiUtils.attachDataText(entityAsString, "RESPONSE");
             if (responseEntity != null) {
                 if (status.getStatusCode() < 400) {
                     entity = (T) entityAsString;
                 } else {
-                    attachName = "RESPONSE ERROR";
                     apiError = new TextError(entityAsString);
                 }
             }
-
-            ApiUtils.attachDataText(entityAsString, attachName);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/taf/src/main/java/com/taf/automation/api/clients/JaxbResponse.java
+++ b/taf/src/main/java/com/taf/automation/api/clients/JaxbResponse.java
@@ -42,17 +42,14 @@ public class JaxbResponse<T> implements GenericHttpResponse<T> {
 
         try {
             entityXML = ApiUtils.prettifyXML(EntityUtils.toString(response.getEntity()));
-            String attachName = "RESPONSE ENTITY";
+            ApiUtils.attachDataXml(entityXML, "RESPONSE");
             if (responseEntity != null) {
                 if (status.getStatusCode() < 400) {
                     entity = getEntityFromXml(responseEntity.getPackage().getName(), entityXML);
                 } else {
-                    attachName = "RESPONSE ERROR";
                     apiError = getEntityFromXml(XmlBaseError.class.getPackage().getName(), entityXML);
                 }
             }
-
-            ApiUtils.attachDataXml(entityXML, attachName);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/taf/src/main/java/com/taf/automation/api/clients/JsonResponse.java
+++ b/taf/src/main/java/com/taf/automation/api/clients/JsonResponse.java
@@ -33,17 +33,14 @@ public class JsonResponse<T> implements GenericHttpResponse<T> {
 
         try {
             entityJSON = EntityUtils.toString(response.getEntity());
-            String attachName = "RESPONSE ENTITY";
+            ApiUtils.attachDataJson(entityJSON, "RESPONSE");
             if (responseEntity != null) {
                 if (status.getStatusCode() < 400) {
                     entity = getEntityFromJson(responseEntity, entityJSON);
                 } else {
-                    attachName = "RESPONSE ERROR";
                     apiError = getEntityFromJson((Class<T>) JsonError.class, entityJSON);
                 }
             }
-
-            ApiUtils.attachDataJson(entityJSON, attachName);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/taf/src/main/java/com/taf/automation/api/clients/XmlResponse.java
+++ b/taf/src/main/java/com/taf/automation/api/clients/XmlResponse.java
@@ -52,17 +52,14 @@ public class XmlResponse<T> implements GenericHttpResponse<T> {
 
         try {
             entityXML = ApiUtils.prettifyXML(EntityUtils.toString(response.getEntity()));
-            String attachName = "RESPONSE ENTITY";
+            ApiUtils.attachDataXml(entityXML, "RESPONSE");
             if (responseEntity != null) {
                 if (status.getStatusCode() < 400) {
                     entity = getEntityFromXml(responseEntity, entityXML);
                 } else {
-                    attachName = "RESPONSE ERROR";
                     apiError = getEntityFromXml(XmlError.class, entityXML);
                 }
             }
-
-            ApiUtils.attachDataXml(entityXML, attachName);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
This makes troubleshooting bad responses easier as it will be report.  (Before you would need to set a break point before the response was parsed to see it.