### PR TITLE
Fix logic error that could lead to stale element exception with AJAX

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/components/RadioButtonGroup.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/components/RadioButtonGroup.java
@@ -104,6 +104,7 @@ public class RadioButtonGroup<T extends PageComponent> extends PageComponent {
             T component = getInstanceOfT(option);
             if (isMatchedOption(component.getText(), theData)) {
                 component.setValue();
+                return;
             }
         }
     }


### PR DESCRIPTION
The loop should exit once a match is found.  If not, then you will set the last matching option.  Also, if setting the value causes the page to become refresh, then a stale element exception will occur.