### PR TITLE
Make method public

### DIFF
--- a/taf/src/main/java/com/taf/automation/ui/support/Helper.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/Helper.java
@@ -394,7 +394,7 @@ public class Helper {
      * @param <T>           - Type
      */
     @Step("Validate {0}")
-    private static <T> void assertThatListItem(String type, AssertAggregator aggregator, T actual, T expected, List<String> excludeFields) {
+    public static <T> void assertThatListItem(String type, AssertAggregator aggregator, T actual, T expected, List<String> excludeFields) {
         assertThat(aggregator, actual, expected, excludeFields);
     }
 


### PR DESCRIPTION
Sometimes you may be validating an object and you want this validation to appear in the report in its own group.  Making this method public saves the few lines of code it takes to do this.