### PR TITLE
Move Allure attachments into separate class to make upgrading to Allure 2 easier

### DIFF
--- a/taf/src/main/java/com/taf/automation/api/ApiUtils.java
+++ b/taf/src/main/java/com/taf/automation/api/ApiUtils.java
@@ -1,6 +1,7 @@
 package com.taf.automation.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.taf.automation.ui.support.testng.Attachment;
 import com.thoughtworks.xstream.XStream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
@@ -13,8 +14,6 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BasicStatusLine;
 import org.xml.sax.InputSource;
-import ru.yandex.qatools.allure.Allure;
-import ru.yandex.qatools.allure.events.MakeAttachmentEvent;
 
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Source;
@@ -76,8 +75,7 @@ public class ApiUtils {
      * @param name - Shown in report as name of attachment
      */
     public static void attachDataXml(String xml, String name) {
-        MakeAttachmentEvent ev = new MakeAttachmentEvent(xml.getBytes(), name, "text/xml");
-        Allure.LIFECYCLE.fire(ev);
+        new Attachment().withTitle(name).withType("text/xml").withFile(xml.getBytes()).build();
     }
 
     /**
@@ -87,8 +85,7 @@ public class ApiUtils {
      * @param name - Shown in report as name of attachment
      */
     public static void attachDataJson(String json, String name) {
-        MakeAttachmentEvent ev = new MakeAttachmentEvent(json.getBytes(), name, "application/json");
-        Allure.LIFECYCLE.fire(ev);
+        new Attachment().withTitle(name).withType("application/json").withFile(json.getBytes()).build();
     }
 
     /**
@@ -98,8 +95,7 @@ public class ApiUtils {
      * @param name - Shown in report as name of attachment
      */
     public static void attachDataText(String text, String name) {
-        MakeAttachmentEvent ev = new MakeAttachmentEvent(text.getBytes(), name, "text/plain");
-        Allure.LIFECYCLE.fire(ev);
+        new Attachment().withTitle(name).withType("text/plain").withFile(text.getBytes()).build();
     }
 
     /**

--- a/taf/src/main/java/com/taf/automation/api/JsonUtils.java
+++ b/taf/src/main/java/com/taf/automation/api/JsonUtils.java
@@ -1,8 +1,7 @@
 package com.taf.automation.api;
 
 import com.google.gson.Gson;
-import ru.yandex.qatools.allure.Allure;
-import ru.yandex.qatools.allure.events.MakeAttachmentEvent;
+import com.taf.automation.ui.support.testng.Attachment;
 
 public class JsonUtils {
     private JsonUtils() {
@@ -32,8 +31,7 @@ public class JsonUtils {
      * @param attachName - Attachment name
      */
     public static void attachJsonToReport(String json, String attachName) {
-        MakeAttachmentEvent ev = new MakeAttachmentEvent(json.getBytes(), attachName, "text/html");
-        Allure.LIFECYCLE.fire(ev);
+        new Attachment().withTitle(attachName).withType("text/html").withFile(json.getBytes()).build();
     }
 
 }

--- a/taf/src/main/java/com/taf/automation/ui/support/Accessibility.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/Accessibility.java
@@ -1,13 +1,12 @@
 package com.taf.automation.ui.support;
 
 import com.deque.axe.AXE;
+import com.taf.automation.ui.support.testng.Attachment;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import ru.yandex.qatools.allure.Allure;
 import ru.yandex.qatools.allure.annotations.Step;
-import ru.yandex.qatools.allure.events.MakeAttachmentEvent;
 import ui.auto.core.pagecomponent.PageComponent;
 
 import java.net.URL;
@@ -200,8 +199,7 @@ public class Accessibility {
         }
 
         String violationDetails = AXE.report(violations);
-        MakeAttachmentEvent ev = new MakeAttachmentEvent(violationDetails.getBytes(), "Violations", "text/plain");
-        Allure.LIFECYCLE.fire(ev);
+        new Attachment().withTitle("Violations").withType("text/plain").withFile(violationDetails.getBytes()).build();
     }
 
     /**

--- a/taf/src/main/java/com/taf/automation/ui/support/Documenter.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/Documenter.java
@@ -1,10 +1,9 @@
 package com.taf.automation.ui.support;
 
+import com.taf.automation.ui.support.testng.Attachment;
 import com.taf.automation.ui.support.testng.TestNGBase;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
-import ru.yandex.qatools.allure.Allure;
-import ru.yandex.qatools.allure.events.MakeAttachmentEvent;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -24,7 +23,7 @@ public class Documenter {
     /**
      * All the stored attachment events
      */
-    private List<MakeAttachmentEvent> attachmentEvents;
+    private List<Attachment> attachmentEvents;
 
     /**
      * Constructor that sets documentation mode to false
@@ -95,11 +94,15 @@ public class Documenter {
         if (documentationMode && TestNGBase.context() != null && TestNGBase.context().getDriver() != null) {
             String alertText = Utils.dismissAlertIfPresent(TestNGBase.context().getDriver());
             if (alertText != null) {
-                attachmentEvents.add(new MakeAttachmentEvent(alertText.getBytes(), "Alert on " + title, "text/plain"));
+                Attachment alertAttachment = new Attachment()
+                        .withTitle("Alert on " + title)
+                        .withType("text/plain")
+                        .withFile(alertText.getBytes());
+                attachmentEvents.add(alertAttachment);
             }
 
             byte[] attachment = ((TakesScreenshot) TestNGBase.context().getDriver()).getScreenshotAs(OutputType.BYTES);
-            attachmentEvents.add(new MakeAttachmentEvent(attachment, title, "image/png"));
+            attachmentEvents.add(new Attachment().withTitle(title).withType("image/png").withFile(attachment));
         }
     }
 
@@ -110,8 +113,8 @@ public class Documenter {
      * 2) If no associated step, then all attachment events will be at the root level<BR>
      */
     public void flush() {
-        for (Iterator<MakeAttachmentEvent> iterator = attachmentEvents.iterator(); iterator.hasNext(); ) {
-            Allure.LIFECYCLE.fire(iterator.next());
+        for (Iterator<Attachment> iterator = attachmentEvents.iterator(); iterator.hasNext(); ) {
+            iterator.next().build();
             iterator.remove();
         }
     }

--- a/taf/src/main/java/com/taf/automation/ui/support/ExpectedConditionsUtil.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/ExpectedConditionsUtil.java
@@ -4,6 +4,7 @@ import com.taf.automation.ui.support.conditional.Conditional;
 import com.taf.automation.ui.support.conditional.Criteria;
 import com.taf.automation.ui.support.conditional.CriteriaMaker;
 import com.taf.automation.ui.support.conditional.ResultType;
+import com.taf.automation.ui.support.testng.Attachment;
 import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
@@ -14,7 +15,6 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.Select;
-import ru.yandex.qatools.allure.events.MakeAttachmentEvent;
 import ui.auto.core.pagecomponent.PageComponent;
 
 import java.util.ArrayList;
@@ -290,7 +290,7 @@ public class ExpectedConditionsUtil {
      * @param title - Title for the screenshot
      * @return List of attachments
      */
-    public static ExpectedCondition<List<MakeAttachmentEvent>> takeScreenshot(final String title) {
+    public static ExpectedCondition<List<Attachment>> takeScreenshot(final String title) {
         return takeScreenshot(title, TestProperties.getInstance().isViewPortOnly());
     }
 
@@ -302,10 +302,10 @@ public class ExpectedConditionsUtil {
      * @param viewPortOnly - true to only take screenshot of the view port, false to attempt full screenshot
      * @return List of attachments
      */
-    public static ExpectedCondition<List<MakeAttachmentEvent>> takeScreenshot(final String title, final boolean viewPortOnly) {
-        return new ExpectedCondition<List<MakeAttachmentEvent>>() {
+    public static ExpectedCondition<List<Attachment>> takeScreenshot(final String title, final boolean viewPortOnly) {
+        return new ExpectedCondition<List<Attachment>>() {
             @Override
-            public List<MakeAttachmentEvent> apply(WebDriver driver) {
+            public List<Attachment> apply(WebDriver driver) {
                 try {
                     List<Criteria> criteria = new ArrayList<>();
                     criteria.add(CriteriaMaker.forAlertDismiss());
@@ -316,10 +316,14 @@ public class ExpectedConditionsUtil {
                         return null;
                     }
 
-                    List<MakeAttachmentEvent> screenshots = new ArrayList<>();
+                    List<Attachment> screenshots = new ArrayList<>();
                     if (index == 0) {
                         String alertText = (String) conditional.getResultInfo().getAdditionalInfo().get(ResultType.VALUE);
-                        screenshots.add(new MakeAttachmentEvent(alertText.getBytes(), "Alert on " + title, "text/plain"));
+                        Attachment alertAttachment = new Attachment()
+                                .withTitle("Alert on " + title)
+                                .withType("text/plain")
+                                .withFile(alertText.getBytes());
+                        screenshots.add(alertAttachment);
                     }
 
                     byte[] attachment;
@@ -337,7 +341,11 @@ public class ExpectedConditionsUtil {
                         append = "_ViewPortOnly";
                     }
 
-                    screenshots.add(new MakeAttachmentEvent(ScreenshotUtil.convertPngToJpg(attachment), title + append, "image/jpeg"));
+                    Attachment jpeg = new Attachment()
+                            .withTitle(title + append)
+                            .withType("image/jpeg")
+                            .withFile(ScreenshotUtil.convertPngToJpg(attachment));
+                    screenshots.add(jpeg);
                     return screenshots;
                 } catch (Exception ex) {
                     return null;

--- a/taf/src/main/java/com/taf/automation/ui/support/Utils.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/Utils.java
@@ -1,6 +1,7 @@
 package com.taf.automation.ui.support;
 
 import com.google.common.base.Function;
+import com.taf.automation.ui.support.testng.Attachment;
 import com.taf.automation.ui.support.testng.TestNGBase;
 import com.thoughtworks.xstream.XStream;
 import datainstiller.data.DataPersistence;
@@ -20,8 +21,6 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.RemoteWebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
-import ru.yandex.qatools.allure.Allure;
-import ru.yandex.qatools.allure.events.MakeAttachmentEvent;
 import ui.auto.core.data.DataTypes;
 import ui.auto.core.pagecomponent.PageComponent;
 import ui.auto.core.utils.AjaxTriggeredAction;
@@ -395,15 +394,14 @@ public class Utils {
         if (path != null) {
             try {
                 // The path comes from the data-set file which should always use slash
-                name = "..." + path.substring(path.lastIndexOf("/"));
+                name = "..." + path.substring(path.lastIndexOf('/'));
             } catch (Exception ex) {
                 // Fallback if parsing fails
                 name = path;
             }
         }
 
-        MakeAttachmentEvent ev = new MakeAttachmentEvent(attachment, name, "text/xml");
-        Allure.LIFECYCLE.fire(ev);
+        new Attachment().withTitle(name).withType("text/xml").withFile(attachment).build();
     }
 
     /**

--- a/taf/src/main/java/com/taf/automation/ui/support/csv/CsvUtils.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/csv/CsvUtils.java
@@ -7,6 +7,7 @@ import com.taf.automation.ui.support.FilloUtils;
 import com.taf.automation.ui.support.Helper;
 import com.taf.automation.ui.support.RegExUtils;
 import com.taf.automation.ui.support.Utils;
+import com.taf.automation.ui.support.testng.Attachment;
 import com.taf.automation.ui.support.testng.TestNGBase;
 import com.taf.automation.ui.support.testng.TestNGBaseWithoutListeners;
 import com.thoughtworks.xstream.annotations.XStreamOmitField;
@@ -25,8 +26,6 @@ import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.openqa.selenium.By;
 import org.testng.ITestContext;
-import ru.yandex.qatools.allure.Allure;
-import ru.yandex.qatools.allure.events.MakeAttachmentEvent;
 import ui.auto.core.context.PageComponentContext;
 import ui.auto.core.data.DataTypes;
 import ui.auto.core.pagecomponent.PageComponent;
@@ -202,8 +201,7 @@ public class CsvUtils {
      */
     public static void attachDataSet(DataPersistence data, String title) {
         byte[] attachment = data.toXML().getBytes();
-        MakeAttachmentEvent ev = new MakeAttachmentEvent(attachment, title, "text/xml");
-        Allure.LIFECYCLE.fire(ev);
+        new Attachment().withTitle(title).withType("text/xml").withFile(attachment).build();
     }
 
     /**

--- a/taf/src/main/java/com/taf/automation/ui/support/testng/Attachment.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/testng/Attachment.java
@@ -1,0 +1,76 @@
+package com.taf.automation.ui.support.testng;
+
+import ru.yandex.qatools.allure.Allure;
+import ru.yandex.qatools.allure.events.MakeAttachmentEvent;
+
+/**
+ * This class holds information to add an attachment to the Allure report
+ */
+public class Attachment {
+    private String title;
+    private String type;
+    private byte[] file;
+
+    /**
+     * @return the title of attachment. Shown at report as name of attachment
+     */
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * Set title of attachment. Shown at report as name of attachment
+     *
+     * @param title - title
+     * @return Attachment
+     */
+    public Attachment withTitle(String title) {
+        this.title = title;
+        return this;
+    }
+
+    /**
+     * @return MIME-type of attachment
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * Set MIME-type of attachment
+     *
+     * @param type - MIME-type
+     * @return Attachment
+     */
+    public Attachment withType(String type) {
+        this.type = type;
+        return this;
+    }
+
+    /**
+     * @return file as byte array
+     */
+    public byte[] getFile() {
+        return file;
+    }
+
+    /**
+     * Set file attachment
+     *
+     * @param file - file as byte array
+     * @return Attachment
+     */
+    public Attachment withFile(byte[] file) {
+        this.file = file;
+        return this;
+    }
+
+    /**
+     * Use the data of the class to add an attachment to the Allure report
+     */
+    public void build() {
+        MakeAttachmentEvent ev = new MakeAttachmentEvent(getFile(), getTitle(), getType());
+        Allure.LIFECYCLE.fire(ev);
+    }
+
+}

--- a/taf/src/main/java/com/taf/automation/ui/support/testng/TestNGBaseWithoutListeners.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/testng/TestNGBaseWithoutListeners.java
@@ -17,8 +17,6 @@ import org.testng.ITestResult;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.BeforeTest;
-import ru.yandex.qatools.allure.Allure;
-import ru.yandex.qatools.allure.events.MakeAttachmentEvent;
 import ui.auto.core.pagecomponent.PageObject;
 
 import java.io.File;
@@ -49,14 +47,13 @@ public class TestNGBaseWithoutListeners {
             try {
                 Utils.getWebDriverWait()
                         .until(ExpectedConditionsUtil.takeScreenshot(title))
-                        .forEach(Allure.LIFECYCLE::fire);
+                        .forEach(Attachment::build);
             } catch (Exception ex) {
                 String shortMessage = "Could not take screenshot for " + title;
                 StringWriter sw = new StringWriter();
                 ex.printStackTrace(new PrintWriter(sw));
                 String fullMessage = shortMessage + " due to exception:  \n\n" + sw.toString();
-                MakeAttachmentEvent ev = new MakeAttachmentEvent(fullMessage.getBytes(), shortMessage, "text/plain");
-                Allure.LIFECYCLE.fire(ev);
+                new Attachment().withTitle(shortMessage).withType("text/plain").withFile(fullMessage.getBytes()).build();
             }
         }
     }
@@ -82,8 +79,7 @@ public class TestNGBaseWithoutListeners {
                 type = "text/plain";
             }
 
-            MakeAttachmentEvent ev = new MakeAttachmentEvent(attachmentFile, attachmentTitle, type);
-            Allure.LIFECYCLE.fire(ev);
+            new Attachment().withTitle(attachmentTitle).withType(type).withFile(attachmentFile).build();
         }
     }
 
@@ -266,8 +262,7 @@ public class TestNGBaseWithoutListeners {
     protected void attachDataSet(DataPersistence data, String name) {
         if (context() != null && context().getDriver() != null) {
             byte[] attachment = data.toXML().getBytes();
-            MakeAttachmentEvent ev = new MakeAttachmentEvent(attachment, name, "text/xml");
-            Allure.LIFECYCLE.fire(ev);
+            new Attachment().withTitle(name).withType("text/xml").withFile(attachment).build();
         }
     }
 


### PR DESCRIPTION
The way in which attachments are added in Allure 2 is different.  So, by having a single class responsible for the attachments will make upgrading to Allure 2 easier (at least for attachments.)