### PR TITLE
Upgrade to TestNG 6.14.3 and fix issue with retries

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/AllureFunctionalityTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/AllureFunctionalityTest.java
@@ -1,0 +1,104 @@
+package com.automation.common.ui.app.tests;
+
+import com.automation.common.ui.app.domainObjects.TNHC_DO;
+import com.taf.automation.ui.support.Rand;
+import com.taf.automation.ui.support.TestProperties;
+import com.taf.automation.ui.support.testng.Retry;
+import com.taf.automation.ui.support.testng.TestNGBase;
+import org.apache.commons.lang3.BooleanUtils;
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+import ru.yandex.qatools.allure.annotations.Description;
+import ru.yandex.qatools.allure.annotations.Features;
+import ru.yandex.qatools.allure.annotations.Issue;
+import ru.yandex.qatools.allure.annotations.Severity;
+import ru.yandex.qatools.allure.annotations.Step;
+import ru.yandex.qatools.allure.annotations.Stories;
+import ru.yandex.qatools.allure.model.SeverityLevel;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class AllureFunctionalityTest extends TestNGBase {
+    private static final int MAIN_STEPS = 10;
+    private static final int NESTED_METHODS = 5;
+    private static final int NESTED_STEPS_BEFORE = 3;
+    private static final int NESTED_STEPS_AFTER = 2;
+    private static final String RANDOM_ACTION = "Random action ";
+
+    @Features("Allure")
+    @Stories("Have the allure report with all functionality")
+    @Severity(SeverityLevel.CRITICAL)
+    @Parameters({"data-set", "status"})
+    @Issue("Issue-001")
+    @Description("This is a test description")
+    @Test
+    @Retry
+    public void performTest(@Optional("data/ui/TNHC_TestData.xml") String dataSet, @Optional("true") String status) {
+        // Attachment test
+        new TNHC_DO(getContext()).fromResource(dataSet);
+        getContext().getDriver().get(TestProperties.getInstance().getURL());
+
+        performLogin();
+        performStatusValidation(status);
+        for (int i = 0; i < MAIN_STEPS; i++) {
+            writeToReport("Perform Random Action:  " + Rand.alphanumeric(5));
+        }
+
+        generateNestedSteps();
+        performSignOut();
+    }
+
+    @Step("Perform Login")
+    private void performLogin() {
+        writeToReport("Enter Login");
+        writeToReport("Enter Password");
+        writeToReport("Click Login");
+    }
+
+    @Step("Perform Status Parameter Validation")
+    private void performStatusValidation(String status) {
+        assertThat("Status Parameter", BooleanUtils.toBoolean(status));
+    }
+
+    @Step("Generate Nested Steps")
+    private void generateNestedSteps() {
+        for (int i = 0; i < NESTED_STEPS_BEFORE; i++) {
+            writeToReport(RANDOM_ACTION + Rand.alphanumeric(4));
+        }
+
+        generateNestedSteps(1, NESTED_METHODS);
+
+        for (int i = 0; i < NESTED_STEPS_AFTER; i++) {
+            writeToReport(RANDOM_ACTION + Rand.alphanumeric(2));
+        }
+    }
+
+    @Step("Generate Nested Steps:  Start({0}), Stop({1})")
+    private void generateNestedSteps(int start, int stop) {
+        if (start == stop) {
+            return;
+        }
+
+        for (int i = 0; i < NESTED_STEPS_BEFORE; i++) {
+            writeToReport(RANDOM_ACTION + Rand.alphanumeric(3));
+        }
+
+        generateNestedSteps(start + 1, stop);
+
+        for (int i = 0; i < NESTED_STEPS_AFTER; i++) {
+            writeToReport(RANDOM_ACTION + Rand.alphanumeric(5));
+        }
+    }
+
+    @Step("Perform Sign Out")
+    private void performSignOut() {
+        //
+    }
+
+    @Step("{0}")
+    private void writeToReport(String value) {
+        // Just write to report
+    }
+
+}

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/RetryTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/RetryTest.java
@@ -1,0 +1,22 @@
+package com.automation.common.ui.app.tests;
+
+import com.taf.automation.ui.support.testng.Retry;
+import com.taf.automation.ui.support.testng.TestNGBase;
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class RetryTest extends TestNGBase {
+    private MutableInt attempt;
+
+    @Test
+    @Retry
+    public void testThatPassesOnRetry() {
+        if (attempt == null) {
+            attempt = new MutableInt(0);
+            assertThat("Always fails 1st time", false);
+        }
+    }
+
+}

--- a/automation-tests/src/main/resources/suites/UnversionedTests.xml
+++ b/automation-tests/src/main/resources/suites/UnversionedTests.xml
@@ -16,6 +16,28 @@
         </classes>
     </test>
 
+    <test name="Allure Functionality Test">
+        <parameter name="data-set" value="data/ui/TNHC_TestData.xml"/>
+        <parameter name="status" value="true"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.AllureFunctionalityTest"/>
+        </classes>
+    </test>
+
+    <test name="Allure Functionality Test #2">
+        <parameter name="data-set" value="data/ui/TNHC_TestData.xml"/>
+        <parameter name="status" value="0"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.AllureFunctionalityTest"/>
+        </classes>
+    </test>
+
+    <test name="Retry with Pass Test">
+        <classes>
+            <class name="com.automation.common.ui.app.tests.RetryTest"/>
+        </classes>
+    </test>
+
     <!--
     <test name="Excel 2013 Test">
         <parameter name="excel" value="data/ui/excel-test-cases.xlsx"/>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <aspectj.version>1.8.7</aspectj.version>
         <selenium.version>3.11.0</selenium.version>
         <page-component.version>1.3.3</page-component.version>
-        <testNg.version>6.11</testNg.version>
+        <testNg.version>6.14.3</testNg.version>
         <hamcrest.version>1.3</hamcrest.version>
         <jetty-server.version>9.4.3.v20170317</jetty-server.version>
         <java.mail.version>1.4.1</java.mail.version>

--- a/taf/src/main/java/com/taf/automation/ui/support/testng/AllureTestNGListener.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/testng/AllureTestNGListener.java
@@ -29,6 +29,16 @@ public class AllureTestNGListener extends AllureTestListener {
     }
 
     @Override
+    public void onTestSuccess(ITestResult iTestResult) {
+        super.onTestSuccess(iTestResult);
+        if (iTestResult.getMethod().getRetryAnalyzer() != null) {
+            // Workaround issue with retries in the TestNG logic added in 6.12
+            iTestResult.getTestContext().getSkippedTests().removeResult(iTestResult.getMethod());
+            iTestResult.getTestContext().getFailedTests().removeResult(iTestResult.getMethod());
+        }
+    }
+
+    @Override
     public void onTestFailure(ITestResult iTestResult) {
         Allure.LIFECYCLE.fire(new TestCaseFailureEvent().withThrowable(iTestResult.getThrowable()));
         TestNGBase.takeScreenshot("Failed Test Screenshot");


### PR DESCRIPTION
Added Retry Test to verify the status code is 0 when there is a failure but on re-try it is successful.
Fix sonar violation in RunTests.
Added test for the general functionality of Allure (this can be used to compare when upgrading to v2.)