### PR TITLE
Add test that can open an existing allure report

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/OpenAllureReportTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/OpenAllureReportTest.java
@@ -1,0 +1,23 @@
+package com.automation.common.ui.app.tests;
+
+import com.taf.automation.ui.support.TestRunner;
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class OpenAllureReportTest {
+    @Parameters("allure-report")
+    @Test
+    public void performOpenReport(@Optional("target/allure-report") String reportFolder) {
+        TestRunner runner = new TestRunner();
+        runner.setReportFolder(reportFolder);
+        try {
+            runner.openReport();
+        } catch (Exception ex) {
+            assertThat("Could not open report due to exception:  " + ex.getMessage(), false);
+        }
+    }
+
+}

--- a/automation-tests/src/main/resources/suites/UnversionedTests.xml
+++ b/automation-tests/src/main/resources/suites/UnversionedTests.xml
@@ -39,6 +39,15 @@
     </test>
 
     <!--
+    <test name="Open Report Test">
+        <parameter name="allure-report" value="/target/allure-report"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.OpenAllureReportTest"/>
+        </classes>
+    </test>
+    -->
+
+    <!--
     <test name="Excel 2013 Test">
         <parameter name="excel" value="data/ui/excel-test-cases.xlsx"/>
         <parameter name="worksheet" value="Sheet1"/>

--- a/taf/src/main/java/com/taf/automation/ui/support/TestRunner.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/TestRunner.java
@@ -135,4 +135,8 @@ public class TestRunner {
         }
     }
 
+    public void setReportFolder(String reportFolder) {
+        this.reportFolder = reportFolder;
+    }
+
 }


### PR DESCRIPTION
For QA Developers this is not necessary.  This is made for QA/Users that are on locked down computers and do not have Firefox installed.  This will allow them to open existing reports on locked down computers using the default browser.