### PR TITLE
Add regex to match basic valid website URL

### DIFF
--- a/taf/src/main/java/com/taf/automation/ui/support/RegExUtils.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/RegExUtils.java
@@ -6,6 +6,7 @@ package com.taf.automation.ui.support;
 public class RegExUtils {
     public static final String NOT_ALPHANUMERIC = "\\W";
     public static final String NOT_DIGITS = "\\D";
+    public static final String HTTP = "http.*";
 
     /**
      * Matches anything including newline.  Use of this should be limited.<BR>


### PR DESCRIPTION
Sometimes when you click a link and it opens a new window it necessary to wait for the about:blank page to be removed and at the website URL to indicate the page is loading.  This is a convenient regular expression that can be used with ExpectedConditions.urlMatches to achieve this in general.