### PR TITLE
Disable attaching sources and JavaDocs

### DIFF
--- a/automation-tests/pom.xml
+++ b/automation-tests/pom.xml
@@ -15,6 +15,11 @@
 
     <build>
         <plugins>
+            <!--
+            Disable attaching sources and JavaDocs as it only needs to be done if uploading
+            to a central nexus like maven central
+            -->
+            <!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
@@ -41,6 +46,7 @@
                     </execution>
                 </executions>
             </plugin>
+            -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>


### PR DESCRIPTION
as it only needs to be done if uploading to a central nexus like maven central

This will speed up compiling significantly.