### PR TITLE
Go back to last version with clock (to prevent library conflict)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <allure.version>1.4.19</allure.version>
         <aspectj.maven.plugin.version>1.8</aspectj.maven.plugin.version>
         <aspectj.version>1.8.7</aspectj.version>
-        <selenium.version>3.141.59</selenium.version>
+        <selenium.version>3.13.0</selenium.version>
         <page-component.version>1.3.3</page-component.version>
         <testNg.version>6.14.3</testNg.version>
         <hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION
The page-component artifact has a conflict when using latest version of selenium which removes the clock interface.  Until the conflict can be resolved (via the pom) revert to last version with the interface.