### PR TITLE
Interface to extract column positions

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/domainObjects/HerokuappColumnMapping.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/domainObjects/HerokuappColumnMapping.java
@@ -1,0 +1,29 @@
+package com.automation.common.ui.app.domainObjects;
+
+import com.taf.automation.ui.support.csv.ColumnMapper;
+
+public enum HerokuappColumnMapping implements ColumnMapper {
+    LAST_NAME("Last Name"),
+    FIRST_NAME("First Name"),
+    EMAIL("Email"),
+    DUE("Due"),
+    WEB_SITE("Web Site"),
+    ACTION("Action");
+
+    private String columnName;
+
+    HerokuappColumnMapping(String columnName) {
+        this.columnName = columnName;
+    }
+
+    @Override
+    public String getColumnName() {
+        return columnName;
+    }
+
+    @Override
+    public ColumnMapper[] getValues() {
+        return values();
+    }
+
+}

--- a/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/HerokuappColumnPositionsExtractor.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/HerokuappColumnPositionsExtractor.java
@@ -1,0 +1,18 @@
+package com.automation.common.ui.app.pageObjects;
+
+import com.taf.automation.ui.support.ColumnPositionsExtractor;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+public class HerokuappColumnPositionsExtractor implements ColumnPositionsExtractor {
+    @Override
+    public By getColumnHeadersLocator() {
+        return By.xpath("//*[@id='table1']/thead/tr/th");
+    }
+
+    @Override
+    public String extractHeaderAsKey(WebElement header, int position) {
+        return header.findElement(By.cssSelector("span")).getText();
+    }
+
+}

--- a/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/HerokuappDataTable1Page.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/HerokuappDataTable1Page.java
@@ -1,0 +1,74 @@
+package com.automation.common.ui.app.pageObjects;
+
+import com.automation.common.ui.app.domainObjects.HerokuappColumnMapping;
+import com.taf.automation.ui.support.JsUtils;
+import com.taf.automation.ui.support.PageObjectV2;
+import com.taf.automation.ui.support.Rand;
+import com.taf.automation.ui.support.TestContext;
+import com.taf.automation.ui.support.Utils;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.taf.automation.ui.support.AssertsUtil.range;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Herokuapp Data Tables Page<BR>
+ * Site:  <a href="https://the-internet.herokuapp.com/tables">https://the-internet.herokuapp.com/tables</a><BR>
+ */
+public class HerokuappDataTable1Page extends PageObjectV2 {
+    private static final By TABLE1_ROWS = By.cssSelector("#table1 tbody tr");
+    private List<HerokuappRowTable1> cached;
+
+    public HerokuappDataTable1Page() {
+        super();
+    }
+
+    public HerokuappDataTable1Page(TestContext context) {
+        super(context);
+    }
+
+    public HerokuappRowTable1 getRow(int index) {
+        List<HerokuappRowTable1> all = getAllRows();
+        assertThat("Invalid Index", index, range(0, all.size() - 1));
+        return all.get(index);
+    }
+
+    public List<HerokuappRowTable1> getAllRows() {
+        if (cached != null) {
+            return cached;
+        }
+
+        List<HerokuappRowTable1> all = new ArrayList<>();
+
+        HerokuappColumnPositionsExtractor extractor = new HerokuappColumnPositionsExtractor();
+        Map<String, String> columnPositions = extractor.getMap();
+        Map<String, String> substitutions = extractor.getSubstitutions(HerokuappColumnMapping.LAST_NAME, columnPositions);
+
+        String randomBaseValue = Rand.letters(10);
+        List<WebElement> rows = Utils.getWebDriverWait().until(ExpectedConditions.numberOfElementsToBeMoreThan(TABLE1_ROWS, 0));
+        for (int i = 0; i < rows.size(); i++) {
+            String randomIdValue = randomBaseValue + i;
+            JsUtils.addAttributeId(rows.get(i), randomIdValue);
+
+            HerokuappRowTable1 row = new HerokuappRowTable1();
+            row.updateRowIdKey(randomIdValue);
+            row.updateSubstitutions(substitutions);
+            row.initPage(getContext());
+            all.add(row);
+        }
+
+        return all;
+    }
+
+    public HerokuappDataTable1Page reset() {
+        cached = null;
+        return this;
+    }
+
+}

--- a/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/HerokuappDataTable1Page.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/HerokuappDataTable1Page.java
@@ -44,7 +44,7 @@ public class HerokuappDataTable1Page extends PageObjectV2 {
             return cached;
         }
 
-        List<HerokuappRowTable1> all = new ArrayList<>();
+        cached = new ArrayList<>();
 
         HerokuappColumnPositionsExtractor extractor = new HerokuappColumnPositionsExtractor();
         Map<String, String> columnPositions = extractor.getMap();
@@ -60,10 +60,10 @@ public class HerokuappDataTable1Page extends PageObjectV2 {
             row.updateRowIdKey(randomIdValue);
             row.updateSubstitutions(substitutions);
             row.initPage(getContext());
-            all.add(row);
+            cached.add(row);
         }
 
-        return all;
+        return cached;
     }
 
     public HerokuappDataTable1Page reset() {

--- a/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/HerokuappRowTable1.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/HerokuappRowTable1.java
@@ -1,0 +1,84 @@
+package com.automation.common.ui.app.pageObjects;
+
+import com.taf.automation.ui.support.PageObjectV2;
+import com.taf.automation.ui.support.TestContext;
+import com.thoughtworks.xstream.annotations.XStreamOmitField;
+import org.openqa.selenium.support.FindBy;
+import ui.auto.core.components.WebComponent;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Example of using dynamic locators to work with a row in a table.<BR>
+ * Site:  <a href="https://the-internet.herokuapp.com/tables">https://the-internet.herokuapp.com/tables</a><BR>
+ * Table from Example 2
+ */
+public class HerokuappRowTable1 extends PageObjectV2 {
+    private Map<String, String> substitutions;
+
+    @XStreamOmitField
+    @FindBy(xpath = "//*[@id='${row-id}']/*[position()=${LAST_NAME}]")
+    private WebComponent lastName;
+
+    @XStreamOmitField
+    @FindBy(xpath = "//*[@id='${row-id}']/*[position()=${FIRST_NAME}]")
+    private WebComponent firstName;
+
+    @XStreamOmitField
+    @FindBy(xpath = "//*[@id='${row-id}']/*[position()=${EMAIL}]")
+    private WebComponent email;
+
+    @XStreamOmitField
+    @FindBy(xpath = "//*[@id='${row-id}']/*[position()=${DUE}]")
+    private WebComponent dues;
+
+    @XStreamOmitField
+    @FindBy(xpath = "//*[@id='${row-id}']/*[position()=${WEB_SITE}]")
+    private WebComponent website;
+
+    public HerokuappRowTable1() {
+        super();
+    }
+
+    private Map<String, String> getSubstitutions() {
+        if (substitutions == null) {
+            substitutions = new HashMap<>();
+        }
+
+        return substitutions;
+    }
+
+    public void updateRowIdKey(String value) {
+        getSubstitutions().put("row-id", value);
+    }
+
+    public void updateSubstitutions(Map<String, String> additions) {
+        getSubstitutions().putAll(additions);
+    }
+
+    public void initPage(TestContext context) {
+        initPage(context, getSubstitutions());
+    }
+
+    public String getLastName() {
+        return lastName.getText();
+    }
+
+    public String getFirstName() {
+        return firstName.getText();
+    }
+
+    public String getEmail() {
+        return email.getText();
+    }
+
+    public String getDues() {
+        return dues.getText();
+    }
+
+    public String getWebsite() {
+        return website.getText();
+    }
+
+}

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/HerokuappDataTableEqualsTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/HerokuappDataTableEqualsTest.java
@@ -1,0 +1,86 @@
+package com.automation.common.ui.app.tests;
+
+import com.automation.common.ui.app.pageObjects.HerokuappDataTable1Page;
+import com.automation.common.ui.app.pageObjects.HerokuappDataTablesPage;
+import com.automation.common.ui.app.pageObjects.HerokuappRow;
+import com.automation.common.ui.app.pageObjects.HerokuappRowTable1;
+import com.taf.automation.api.JsonUtils;
+import com.taf.automation.ui.support.Utils;
+import com.taf.automation.ui.support.testng.TestNGBase;
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+import ru.yandex.qatools.allure.annotations.Features;
+import ru.yandex.qatools.allure.annotations.Severity;
+import ru.yandex.qatools.allure.annotations.Stories;
+import ru.yandex.qatools.allure.model.SeverityLevel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Testing Dynamic Locators in a page that represents a row in a table
+ */
+public class HerokuappDataTableEqualsTest extends TestNGBase {
+    @SuppressWarnings({"squid:S1068", "squid:S1206"})
+    private class Table {
+        private String lastName;
+        private String firstName;
+        private String email;
+        private String dues;
+        private String website;
+
+        @Override
+        public boolean equals(Object object) {
+            List<String> excludeFields = new ArrayList<>();
+            return Utils.equals(this, object, excludeFields);
+        }
+
+        @Override
+        public String toString() {
+            return JsonUtils.getGson().toJson(this);
+        }
+
+    }
+
+    @Features("Framework")
+    @Stories("Page Object with Dynamic Locators used to represent a row in a table")
+    @Severity(SeverityLevel.CRITICAL)
+    @Parameters("url")
+    @Test
+    public void verifyTable1EqualsTable2Test(@Optional("https://the-internet.herokuapp.com/tables") String url) {
+        getContext().getDriver().get(url);
+
+        List<Table> table2Rows = new ArrayList<>();
+        HerokuappDataTablesPage table2 = new HerokuappDataTablesPage(getContext());
+        List<HerokuappRow> all = table2.getAllRows();
+        for (HerokuappRow row : all) {
+            Table actual = new Table();
+            actual.lastName = row.getLastName();
+            actual.firstName = row.getFirstName();
+            actual.email = row.getEmail();
+            actual.dues = row.getDues();
+            actual.website = row.getWebsite();
+            table2Rows.add(actual);
+        }
+
+        List<Table> table1Rows = new ArrayList<>();
+        HerokuappDataTable1Page table1 = new HerokuappDataTable1Page(getContext());
+        List<HerokuappRowTable1> allTable1Rows = table1.getAllRows();
+        for (HerokuappRowTable1 row : allTable1Rows) {
+            Table actual = new Table();
+            actual.lastName = row.getLastName();
+            actual.firstName = row.getFirstName();
+            actual.email = row.getEmail();
+            actual.dues = row.getDues();
+            actual.website = row.getWebsite();
+            table1Rows.add(actual);
+        }
+
+        assertThat("Table 1 == Table 2", table2Rows, equalTo(table1Rows));
+    }
+
+}

--- a/automation-tests/src/main/resources/suites/UnversionedTests.xml
+++ b/automation-tests/src/main/resources/suites/UnversionedTests.xml
@@ -9,6 +9,13 @@
         </classes>
     </test>
 
+    <test name="Herokuapp Data Table Equals Test">
+        <parameter name="url" value="https://the-internet.herokuapp.com/tables"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.HerokuappDataTableEqualsTest"/>
+        </classes>
+    </test>
+
     <test name="Data Provider Test">
         <parameter name="Data Provider Test" value="data/ui/LinksTestData.xml"/>
         <classes>

--- a/taf/src/main/java/com/taf/automation/ui/support/ColumnPositionsExtractor.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/ColumnPositionsExtractor.java
@@ -1,0 +1,75 @@
+package com.taf.automation.ui.support;
+
+import com.taf.automation.ui.support.csv.ColumnMapper;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Generic class to help with extracting column positions for tables do not have an unique way to
+ * identify cells on a row.
+ */
+public interface ColumnPositionsExtractor {
+    /**
+     * Get the locator to find all the column header elements
+     *
+     * @return By
+     */
+    By getColumnHeadersLocator();
+
+    /**
+     * Extract the header as key
+     *
+     * @param header   - Element that contains the header information
+     * @param position - Position of header column that is being extracted
+     * @return header as key or null if you cannot (or do not want) to extract
+     */
+    String extractHeaderAsKey(WebElement header, int position);
+
+    /**
+     * Get a substitution map using the mapper and column positions
+     *
+     * @param mapper          - Enumeration that maps the column positions to keys
+     * @param columnPositions - Column Positions that contains the map from headers to positions
+     * @return Map with the enumeration as the key and the position as the value
+     */
+    default Map<String, String> getSubstitutions(ColumnMapper mapper, Map<String, String> columnPositions) {
+        Map<String, String> substitutions = new HashMap<>();
+
+        for (Map.Entry<String, String> entry : columnPositions.entrySet()) {
+            ColumnMapper column = mapper.toEnum(entry.getKey());
+            if (column != null) {
+                substitutions.put(column.toString(), entry.getValue());
+            }
+        }
+
+        return substitutions;
+    }
+
+    /**
+     * Get a map with the extracted column positions
+     *
+     * @return Map with headers as the key and the position as the value
+     */
+    default Map<String, String> getMap() {
+        Map<String, String> columnPositions = new HashMap<>();
+
+        int position = 1;
+        List<WebElement> headers = Utils.getWebDriverWait().until(ExpectedConditions.numberOfElementsToBeMoreThan(getColumnHeadersLocator(), 0));
+        for (WebElement header : headers) {
+            String key = extractHeaderAsKey(header, position);
+            if (key != null) {
+                columnPositions.put(key, "" + position);
+            }
+
+            position++;
+        }
+
+        return columnPositions;
+    }
+
+}


### PR DESCRIPTION
Use Case:  There is a table with headers but there is no maintainable way to map the cells in the rows.
Website with problem table:  https://the-internet.herokuapp.com/tables

In this cases, you would normally be forced to map the cells (columns) using positions.  This is not maintainable because additions/removals/moving of the columns will cause the retrieval of information to be incorrect.

With this interface, we try to bring maintainability by mapping dynamically the headers to positions.  In theory, additions/removals/moving of the columns will not affect the existing columns because the positions are dynamically mapped at run-time.