### PR TITLE
Enhance setElementValueV2 to retry

### DIFF
--- a/taf/src/main/java/com/taf/automation/ui/support/Helper.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/Helper.java
@@ -6,6 +6,7 @@ import com.taf.automation.api.network.MultiSshSession;
 import com.taf.automation.ui.support.conditional.Conditional;
 import com.taf.automation.ui.support.conditional.Criteria;
 import com.thoughtworks.xstream.annotations.XStreamOmitField;
+import net.jodah.failsafe.Failsafe;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -182,7 +183,7 @@ public class Helper {
 
         boolean validationFlag = false;
         for (int i = 0; i < retries; i++) {
-            component.setValue();
+            Failsafe.with(Utils.getWriteValueRetryPolicy()).run(component::setValue);
             if (!validate) {
                 validationFlag = true;
                 break;

--- a/taf/src/main/java/com/taf/automation/ui/support/PageObjectV2.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/PageObjectV2.java
@@ -1,5 +1,6 @@
 package com.taf.automation.ui.support;
 
+import net.jodah.failsafe.Failsafe;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.openqa.selenium.By;
@@ -247,10 +248,7 @@ public class PageObjectV2 extends PageObject {
         int attempt = 0;
         boolean validated;
         do {
-            // We could catch any exception here but we are mimicking functionality of PageObject.setElementValue
-            // and this method does not do that
-            component.setValue();
-
+            Failsafe.with(Utils.getWriteValueRetryPolicy()).run(component::setValue);
             if (validationMethod != null) {
                 try {
                     // Execute validation using the component specific logic

--- a/taf/src/main/java/com/taf/automation/ui/support/Utils.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/Utils.java
@@ -16,6 +16,7 @@ import org.apache.http.client.utils.URIBuilder;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.RemoteWebElement;
@@ -950,6 +951,25 @@ public class Utils {
      */
     public static RetryPolicy getPollingRetryPolicy() {
         return new RetryPolicy()
+                .retryOn(Exception.class, AssertionError.class)
+                .withMaxDuration(TestProperties.getInstance().getElementTimeout(), TimeUnit.SECONDS)
+                .withDelay(1, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Get RetryPolicy for writing element values<BR>
+     * <B>Notes: </B>
+     * <UL>
+     * <LI>The max duration is from the TestProperties class</LI>
+     * <LI>Does not retry if stale element exception occurs</LI>
+     * <LI>The RetryPolicy can be used with 'Failsafe.with' to retry writing an element value</LI>
+     * </UL>
+     *
+     * @return RetryPolicy
+     */
+    public static RetryPolicy getWriteValueRetryPolicy() {
+        return new RetryPolicy()
+                .abortOn(StaleElementReferenceException.class)
                 .retryOn(Exception.class, AssertionError.class)
                 .withMaxDuration(TestProperties.getInstance().getElementTimeout(), TimeUnit.SECONDS)
                 .withDelay(1, TimeUnit.SECONDS);


### PR DESCRIPTION
There are some exceptions (like ElementClickInterceptedException) in which retrying to set the element value makes sense.  I have added a retry policy that retries on everything except StaleElementReferenceException.  Additional, exceptions can be made as necessary by modifying this retry policy.