### PR TITLE
Enhanced US Address Generator for user to specify no shuffle

### DIFF
--- a/automation-tests/src/main/resources/data/ui/TNHC_TestData.xml
+++ b/automation-tests/src/main/resources/data/ui/TNHC_TestData.xml
@@ -4,6 +4,21 @@
     <aliases>
         <player>$[CUSTOM_LIST('null', 'zzz,yyy,www,ttt')]</player>
         <value>duplicated</value>
+
+        <!-- Test the generators -->
+        <AddressGenerator>$[ADDRESS('{#} {S}, {T} {K}, {C}','null')]</AddressGenerator>
+        <AlphaNumericGenerator>$[ALPHANUMERIC('{a}{b}{c}{d}{e}', 'null')]</AlphaNumericGenerator>
+        <CustomListGenerator>$[CUSTOM_LIST('null', 'aaa, bbb, ccc')]</CustomListGenerator>
+        <DateGenerator>$[DATE('dd MMM yyyy','2016/01/01|2016/12/31|yyyy/MM/dd')]</DateGenerator>
+        <HumanNameGenerator>$[HUMAN_NAMES('{S}','null')]</HumanNameGenerator>
+        <WordGenerator>$[WORD('|A| {b} {c}','null')]</WordGenerator>
+        <NumberGenerator>$[NUMBER('000','200,999')]</NumberGenerator>
+
+        <RandomDateGenerator>$[RANDOM_DATE('yyyy-MM-dd','365|720')]</RandomDateGenerator>
+        <RandomRealUSAddressGenerator1>$[RANDOM_US_ADDRESS('{#} {C} {S} {Z} {U} {P}','')]</RandomRealUSAddressGenerator1>
+        <RandomRealUSAddressGenerator2>$[RANDOM_US_ADDRESS('{#} {C} {S} {Z} {U} {P}','')]</RandomRealUSAddressGenerator2>
+        <RandomRealUSAddressGenerator3>$[RANDOM_US_ADDRESS('{#} {C} {S} {Z} {U} {P}','NO_SHUFFLE;')]</RandomRealUSAddressGenerator3>
+        <RandomRealUSAddressGenerator4>$[RANDOM_US_ADDRESS('{#} {C} {S} {Z} {U} {P}','NO_SHUFFLE;')]</RandomRealUSAddressGenerator4>
     </aliases>
     <user>user2</user>
     <pass>password</pass>

--- a/taf/src/main/java/com/taf/automation/ui/support/generators/RandomRealUSAddressGenerator.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/generators/RandomRealUSAddressGenerator.java
@@ -23,6 +23,7 @@ import java.util.List;
  * Generator to get a random real US address (McDonald locations)
  */
 public class RandomRealUSAddressGenerator extends File2ListReader implements GeneratorInterface {
+    private static final String NO_SHUFFLE = "NO_SHUFFLE;";
     private List<String> addresses = null;
 
     /**
@@ -143,9 +144,19 @@ public class RandomRealUSAddressGenerator extends File2ListReader implements Gen
     @Override
     public String generate(String pattern, String conditions) {
         initAddresses();
-        Collections.shuffle(addresses);
 
-        if (!StringUtils.defaultString(conditions).equals("")) {
+        boolean shuffle = true;
+        String theConditions = conditions;
+        if (StringUtils.startsWithIgnoreCase(theConditions, NO_SHUFFLE)) {
+            theConditions = StringUtils.removeStartIgnoreCase(conditions, NO_SHUFFLE);
+            shuffle = false;
+        }
+
+        if (shuffle) {
+            Collections.shuffle(addresses);
+        }
+
+        if (!StringUtils.defaultString(theConditions).equals("")) {
             ExpressionParser parser = new BasicParser()
                     .withExpression(new StateEquals())
                     .withExpression(new StateNotEquals())
@@ -155,7 +166,7 @@ public class RandomRealUSAddressGenerator extends File2ListReader implements Gen
                     .withExpression(new ZipCodeEqualsFromList())
                     .withExpression(new ZipCodeSizeEquals5())
                     .withExpression(new ZipCodeSizeEquals9())
-                    .withConditions(conditions);
+                    .withConditions(theConditions);
             for (String rawAddress : addresses) {
                 USAddress checkAddress = parseAddress(rawAddress);
                 if (parser.eval(checkAddress)) {


### PR DESCRIPTION
I have found that you need pieces of the random address to be enter across multiple fields.  It was not possible to get the same random address because each call to the generator shuffles the addresses.  I have added a flag to skip shuffling the addresses such that the same random address can be found.