### PR TITLE
Same Thread Test to validate context is set/retrieved properly

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/SameThreadTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/SameThreadTest.java
@@ -1,0 +1,73 @@
+package com.automation.common.ui.app.tests;
+
+import com.taf.automation.ui.support.Helper;
+import com.taf.automation.ui.support.Utils;
+import com.taf.automation.ui.support.testng.TestNGBase;
+import net.jodah.failsafe.Failsafe;
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+import ru.yandex.qatools.allure.annotations.Step;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+/**
+ * Test to validate the same thread is being used as the framework is assuming this
+ */
+public class SameThreadTest extends TestNGBase {
+    private static final int GREATER_THAN = 4;
+    private long expectedThreadId;
+
+    @BeforeTest
+    private void performSetExpectedThreadId() {
+        // The context is set using BeforeTest as such set the expected thread id
+        expectedThreadId = Thread.currentThread().getId();
+    }
+
+    @Test
+    public void performTest() {
+        Helper.log("Running Test", true);
+        assertThat("During Test", Thread.currentThread().getId(), equalTo(expectedThreadId));
+
+        MutableInt count = new MutableInt(0);
+        Failsafe.with(Utils.getPollingRetryPolicy()).run(() -> validationMethod(count, GREATER_THAN));
+
+        count.setValue(0);
+        Failsafe.with(Utils.getPollingRetryPolicy()).get(() -> getSomeValue(count, GREATER_THAN));
+
+        Helper.log("Completed Test", true);
+    }
+
+    @Step("Validate ({0} + 1) greater than {1}")
+    private void validationMethod(MutableInt count, int value) {
+        assertThat("Failsafe Run Test #" + count, Thread.currentThread().getId(), equalTo(expectedThreadId));
+        count.increment();
+        assertThat("Return Value", count.intValue(), greaterThan(value));
+    }
+
+    private int getSomeValue(MutableInt count, int value) {
+        assertThat("Failsafe Get Test #" + count, Thread.currentThread().getId(), equalTo(expectedThreadId));
+        count.increment();
+        assertThat("Get Value", count.intValue(), greaterThan(value));
+        return count.intValue();
+    }
+
+    @AfterTest
+    private void performAfterTestToEnsureTheBrowserIsClosed() {
+        Helper.log("Running AfterTest", true);
+        assertThat("AfterTest", Thread.currentThread().getId(), equalTo(expectedThreadId));
+        Helper.log("Completed AfterTest", true);
+    }
+
+    @AfterClass
+    private void performAfterClass() {
+        Helper.log("Running AfterClass", true);
+        assertThat("AfterClass", Thread.currentThread().getId(), equalTo(expectedThreadId));
+        Helper.log("Completed AfterClass", true);
+    }
+
+}

--- a/automation-tests/src/main/resources/suites/UnversionedTests.xml
+++ b/automation-tests/src/main/resources/suites/UnversionedTests.xml
@@ -66,6 +66,12 @@
         </classes>
     </test>
 
+    <test name="Same Thread Test">
+        <classes>
+            <class name="com.automation.common.ui.app.tests.SameThreadTest"/>
+        </classes>
+    </test>
+
     <!--
     <test name="Open Report Test">
         <parameter name="allure-report" value="/target/allure-report"/>


### PR DESCRIPTION
**Background**:  The framework is using TestNG to initialize the context before each test and to close the browser after each test.  This information is stored in ThreadLocal variables as such the before/after test methods need to be the same thread as the test method.

As long as you use **parallel="tests"** for TestNG, these methods are run in the same thread and there are no issues.  However, the other TestNG parallel options can/will run these methods in different threads and there are issues.  In addition, setting **time-out="60000"** with **parallel="tests"** will all trigger these methods to be run in different threads and there are issues.

This test can be run in parallel with other tests to validate these methods are running in the same thread to eliminate this as the cause of your issues.