### PR TITLE
Fix compile issue using aspectj-maven-plugin with JDK 11

### DIFF
--- a/automation-tests/pom.xml
+++ b/automation-tests/pom.xml
@@ -48,9 +48,9 @@
             </plugin>
             -->
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>com.nickwongdev</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
-                <version>1.8</version>
+                <version>${aspectj.maven.plugin.version}</version>
                 <configuration>
                     <showWeaveInfo>false</showWeaveInfo>
                     <Xlint>ignore</Xlint>
@@ -75,8 +75,9 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.6</version>
+                <version>${maven-assembly-plugin}</version>
                 <configuration>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,9 @@
     <properties>
         <compiler.version>1.8</compiler.version>
         <allure.version>1.4.19</allure.version>
-        <aspectj.maven.plugin.version>1.8</aspectj.maven.plugin.version>
-        <aspectj.version>1.8.7</aspectj.version>
+        <aspectj.maven.plugin.version>1.12.1</aspectj.maven.plugin.version>
+        <aspectj.version>1.9.2</aspectj.version>
+        <maven-assembly-plugin>2.6</maven-assembly-plugin>
         <selenium.version>3.141.59</selenium.version>
         <page-component.version>1.3.7</page-component.version>
         <testNg.version>6.14.3</testNg.version>

--- a/taf/pom.xml
+++ b/taf/pom.xml
@@ -16,7 +16,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>com.nickwongdev</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
                 <version>${aspectj.maven.plugin.version}</version>
                 <configuration>


### PR DESCRIPTION
**Issue**:  Project works fine with JDK8 but if you use JDK11 the following error occurs when weaving a compile time:  **Could not find artifact com.sun:tools:jar:11.0.4 at specified path /usr/lib/jvm/java-11-openjdk-amd64/../lib/tools.jar**

**Cause**:  Certain JAR files that were part of the JDK 8 have been removed starting in JDK 9.  It seems that the **aspectj-maven-plugin** was using these removed JAR files which caused the issue when weaving at compile time.

**Solution**:  Upgrade the plugin to version that supports JDK 11.  This turns out to be an issue as the project does not seem to be maintained anymore.  However, I was able to find a fork of the project in which someone fixed the issue.