### PR TITLE
Add ability to replace ${env} (case insensitive) with app.environment target property value

### DIFF
--- a/taf/src/main/java/com/taf/automation/ui/support/TestProperties.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/TestProperties.java
@@ -85,6 +85,9 @@ public class TestProperties {
     @Property("app.environment")
     private Environment environment;
 
+    @Property("app.environment.target")
+    private String environmentTarget;
+
     @Use(CredentialsObjectPropertyConverter.class)
     @Property("app.credentials.api")
     @HideInReport
@@ -408,11 +411,19 @@ public class TestProperties {
         return environment.isProdEnv();
     }
 
+    private String replaceWithTargetEnv(String url) {
+        if (url == null || environmentTarget == null) {
+            return url;
+        }
+
+        return url.replaceAll("(?i)\\$\\{env}", environmentTarget);
+    }
+
     public String getApiUrl() {
         if (isProdEnv()) {
             return apiUrlProd;
         } else {
-            return apiUrl;
+            return replaceWithTargetEnv(apiUrl);
         }
     }
 
@@ -610,7 +621,7 @@ public class TestProperties {
         if (isProdEnv()) {
             return urlProd;
         } else {
-            return url;
+            return replaceWithTargetEnv(url);
         }
     }
 


### PR DESCRIPTION
This can make your build system setup simpler provided your application URLs follow a pattern.  You can define all the URLs in the test.properties file (in TAF module) using ${env} and then pass the system property app.environment.target with the environment to test against.

Example **test.properties**:
your.${env}.application.com
your2nd.${env}.application.com
then pass system property **app.environment.target**=QA1 to have the URLs resolved to
your.QA1.application.com
your2nd.QA1.application.com
