### PR TITLE
Re-factoring to make BDD aliases work for API

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/api/tests/NoFeatureFilesForBDDTest.java
+++ b/automation-tests/src/main/java/com/automation/common/api/tests/NoFeatureFilesForBDDTest.java
@@ -1,0 +1,29 @@
+package com.automation.common.api.tests;
+
+import com.automation.common.api.domainObjects.JsonIpDO;
+import com.taf.automation.ui.support.testng.AllureTestNGListener;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+import ru.yandex.qatools.allure.annotations.Features;
+import ru.yandex.qatools.allure.annotations.Severity;
+import ru.yandex.qatools.allure.annotations.Stories;
+import ru.yandex.qatools.allure.model.SeverityLevel;
+
+/**
+ * This is a test to show how to do API - BDD without feature files
+ */
+@Listeners(AllureTestNGListener.class)
+public class NoFeatureFilesForBDDTest {
+    @Features("Framework")
+    @Stories("API - BDD without feature files")
+    @Severity(SeverityLevel.CRITICAL)
+    @Parameters("data-set")
+    @Test
+    public void performTest(@Optional("data/api/NoFeatureFilesForBDDScenario1_TestData.xml") String dataSet) {
+        // Load data which contains the BDD information for the test
+        new JsonIpDO().fromResource(dataSet);
+    }
+
+}

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/NoFeatureFilesForBDDTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/NoFeatureFilesForBDDTest.java
@@ -12,15 +12,15 @@ import ru.yandex.qatools.allure.annotations.Stories;
 import ru.yandex.qatools.allure.model.SeverityLevel;
 
 /**
- * This is a test to show how to do BDD without feature files
+ * This is a test to show how to do GUI - BDD without feature files
  */
 public class NoFeatureFilesForBDDTest extends TestNGBase {
     @Features("Framework")
-    @Stories("BDD without feature files")
+    @Stories("GUI - BDD without feature files")
     @Severity(SeverityLevel.CRITICAL)
     @Parameters({"url", "data-set"})
     @Test
-    public void getAllDataTest(
+    public void performTest(
             @Optional("https://the-internet.herokuapp.com/tables") String url,
             @Optional("data/ui/NoFeatureFilesForBDDScenario1_TestData.xml") String dataSet
     ) {

--- a/automation-tests/src/main/resources/data/api/NoFeatureFilesForBDDScenario1_TestData.xml
+++ b/automation-tests/src/main/resources/data/api/NoFeatureFilesForBDDScenario1_TestData.xml
@@ -1,0 +1,24 @@
+<json-ip-do>
+    <aliases>
+        <!--
+        Aliases that are required to do BDD without feature files, step definitions, glue, etc.
+        It is only necessary to override the ones that you need.  Also, this is only necessary if the
+        same test class is being used with different test data.  (It overrides the annotation in the class.)
+        -->
+        <test-name>API Name #1</test-name>
+        <test-description>API Description #1</test-description>
+        <test-features>API Feature #1</test-features>
+        <test-stories>API Story #1</test-stories>
+        <test-severity>MINOR</test-severity>
+    </aliases>
+
+    <response>
+        <status>
+            <statusCode>200</statusCode>
+            <reasonPhrase>OK</reasonPhrase>
+        </status>
+
+        <about>/about</about>
+        <pro>http://getjsonip.com</pro>
+    </response>
+</json-ip-do>

--- a/automation-tests/src/main/resources/data/api/NoFeatureFilesForBDDScenario2_TestData.xml
+++ b/automation-tests/src/main/resources/data/api/NoFeatureFilesForBDDScenario2_TestData.xml
@@ -1,0 +1,26 @@
+<json-ip-do>
+    <aliases>
+        <!--
+        Aliases that are required to do BDD without feature files, step definitions, glue, etc.
+        It is only necessary to override the ones that you need.  Also, this is only necessary if the
+        same test class is being used with different test data.  (It overrides the annotation in the class.)
+        -->
+        <test-name>API Name #2</test-name>
+        <test-description>API Description #2</test-description>
+        <test-features>API Feature #2</test-features>
+        <test-stories>API Some different story</test-stories>
+        <test-issues>BUG-003,BUG-004</test-issues>
+        <test-IDs>TEST-003,TEST-004</test-IDs>
+        <test-severity>TRIVIAL</test-severity>
+    </aliases>
+
+    <response>
+        <status>
+            <statusCode>200</statusCode>
+            <reasonPhrase>OK</reasonPhrase>
+        </status>
+
+        <about>/about</about>
+        <pro>http://getjsonip.com</pro>
+    </response>
+</json-ip-do>

--- a/automation-tests/src/main/resources/data/api/NoFeatureFilesForBDDScenario3_TestData.xml
+++ b/automation-tests/src/main/resources/data/api/NoFeatureFilesForBDDScenario3_TestData.xml
@@ -1,0 +1,17 @@
+<json-ip-do>
+    <aliases>
+        <!--
+        Let's see what happens when the BDD aliases are not provided
+        -->
+    </aliases>
+
+    <response>
+        <status>
+            <statusCode>200</statusCode>
+            <reasonPhrase>OK</reasonPhrase>
+        </status>
+
+        <about>/about</about>
+        <pro>http://getjsonip.com</pro>
+    </response>
+</json-ip-do>

--- a/automation-tests/src/main/resources/suites/UnversionedTests.xml
+++ b/automation-tests/src/main/resources/suites/UnversionedTests.xml
@@ -96,6 +96,27 @@
         </classes>
     </test>
 
+    <test name="API - BDD without feature files - scenario 1 - Test">
+        <parameter name="data-set" value="data/api/NoFeatureFilesForBDDScenario1_TestData.xml"/>
+        <classes>
+            <class name="com.automation.common.api.tests.NoFeatureFilesForBDDTest"/>
+        </classes>
+    </test>
+
+    <test name="API - BDD without feature files - scenario 2 - Test">
+        <parameter name="data-set" value="data/api/NoFeatureFilesForBDDScenario2_TestData.xml"/>
+        <classes>
+            <class name="com.automation.common.api.tests.NoFeatureFilesForBDDTest"/>
+        </classes>
+    </test>
+
+    <test name="API - BDD without feature files - scenario 3 - Test">
+        <parameter name="data-set" value="data/api/NoFeatureFilesForBDDScenario3_TestData.xml"/>
+        <classes>
+            <class name="com.automation.common.api.tests.NoFeatureFilesForBDDTest"/>
+        </classes>
+    </test>
+
     <!--
     <test name="Open Report Test">
         <parameter name="allure-report" value="/target/allure-report"/>

--- a/taf/src/main/java/com/taf/automation/api/ApiDomainObject.java
+++ b/taf/src/main/java/com/taf/automation/api/ApiDomainObject.java
@@ -66,8 +66,14 @@ public class ApiDomainObject extends DataPersistenceV2 {
     @Override
     public <T extends DataPersistence> T fromResource(String resourceFile) {
         String useResourceFile = Helper.getEnvironmentBasedFile(resourceFile);
+
+        // When resolve alias is true, then the aliases will be made null after loading
+        // as such get the aliases before loading
+        T temp = super.fromResource(useResourceFile, false);
+        DataAliases aliases = temp.getDataAliases();
+
         T dataSet = super.fromResource(useResourceFile, true);
-        DomainObjectUtils.overwriteTestParameters(dataSet);
+        DomainObjectUtils.overwriteTestParameters(aliases);
         Utils.attachDataSet(dataSet, useResourceFile);
         return dataSet;
     }

--- a/taf/src/main/java/com/taf/automation/ui/support/DomainObjectUtils.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/DomainObjectUtils.java
@@ -20,36 +20,46 @@ public class DomainObjectUtils {
         // Prevent initialization of class as all public methods should be static
     }
 
-    private static List<Label> getLabels(DataPersistence data, String labelAlias, LabelName labelName) {
-        DataAliases aliases = data.getDataAliases();
-        String label = aliases.get(labelAlias);
+    private static List<Label> getLabels(DataAliases aliases, String labelAlias, LabelName labelName) {
         List<Label> labels = new ArrayList<>();
+
+        String label = aliases.get(labelAlias);
         if (label != null) {
             for (String value : label.split(",")) {
                 labels.add(new Label().withName(labelName.value()).withValue(value.trim()));
             }
         }
+
         return labels;
     }
 
     public static void overwriteTestParameters(DataPersistence data) {
-        DataAliases aliases = data.getDataAliases();
-        if (aliases == null) return;
+        if (data != null) {
+            overwriteTestParameters(data.getDataAliases());
+        }
+    }
+
+    public static void overwriteTestParameters(DataAliases aliases) {
+        if (aliases == null) {
+            return;
+        }
+
         String name = aliases.get("test-name");
         String description = aliases.get("test-description");
 
         List<Label> labels = new ArrayList<>();
-        labels.addAll(getLabels(data, "test-features", LabelName.FEATURE));
-        labels.addAll(getLabels(data, "test-stories", LabelName.STORY));
-        labels.addAll(getLabels(data, "test-issues", LabelName.ISSUE));
-        labels.addAll(getLabels(data, "test-IDs", LabelName.TEST_ID));
-        labels.addAll(getLabels(data, "test-severity", LabelName.SEVERITY));
+        labels.addAll(getLabels(aliases, "test-features", LabelName.FEATURE));
+        labels.addAll(getLabels(aliases, "test-stories", LabelName.STORY));
+        labels.addAll(getLabels(aliases, "test-issues", LabelName.ISSUE));
+        labels.addAll(getLabels(aliases, "test-IDs", LabelName.TEST_ID));
+        labels.addAll(getLabels(aliases, "test-severity", LabelName.SEVERITY));
 
         Allure.LIFECYCLE.fire((TestCaseEvent) context -> {
             context.getLabels().addAll(labels);
             if (name != null) {
                 context.setName(name);
             }
+
             if (description != null) {
                 context.setDescription(new Description().withType(DescriptionType.MARKDOWN).withValue(description));
             }


### PR DESCRIPTION
The BDD aliases are only applied if resolve aliases is false.  This is problem in the API domain object because resolve aliases is always true.

The root cause is when resolve aliases is true it also makes the aliases variable null.  So, the only way to work around this is to get the aliases before this occurs.  I have done this only for the API domain object because this causes a performance this as the data file is processed twice.