### PR TITLE
Add method to run a lambda expression before setting the value

### DIFF
--- a/taf/src/main/java/com/taf/automation/ui/support/PageObjectV2.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/PageObjectV2.java
@@ -232,6 +232,23 @@ public class PageObjectV2 extends PageObject {
      * <B>Notes:</B><BR>
      * 1) Similar to the PageObject.setElementValue except validation occurs using component's validation method<BR>
      *
+     * @param component            - Component to set value and validate
+     * @param actionBeforeSetValue - Lambda expression to run before setting value
+     */
+    protected void setElementValueV2(PageComponent component, final Runnable actionBeforeSetValue) {
+        if (component == null || component.getData(DataTypes.Data, true) == null || component.getData(DataTypes.Data, true).isEmpty()) {
+            return;
+        }
+
+        actionBeforeSetValue.run();
+        setElementValueV2(component);
+    }
+
+    /**
+     * Set value and validate using component's validation method<BR>
+     * <B>Notes:</B><BR>
+     * 1) Similar to the PageObject.setElementValue except validation occurs using component's validation method<BR>
+     *
      * @param component - Component to set value and validate
      */
     protected void setElementValueV2(PageComponent component) {


### PR DESCRIPTION
If you are dealing with dynamic locators, then it is normally necessary to set the substitutions before setting the value.  This method makes it easier by checking if the component will actually be set before executing the lambda expression to handle the dynamic locators.