### PR TITLE
Fix dynamic locators being set to null

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/HerokuappRow.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/HerokuappRow.java
@@ -4,10 +4,14 @@ import com.taf.automation.ui.support.PageObjectV2;
 import com.taf.automation.ui.support.TestContext;
 import com.thoughtworks.xstream.annotations.XStreamOmitField;
 import org.openqa.selenium.support.FindBy;
+import ru.yandex.qatools.allure.annotations.Step;
 import ui.auto.core.components.WebComponent;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
 
 /**
  * Example of using dynamic locators to work with a row in a table.<BR>
@@ -75,6 +79,16 @@ public class HerokuappRow extends PageObjectV2 {
 
     public String getWebsite() {
         return website.getText();
+    }
+
+    @Step("Validate Locators Not Null")
+    public void validateLocatorsNotNull() {
+        // Due to re-factoring the locators may be changed, this is to ensure that they are not null
+        assertThat("Last Name Locator", lastName.getLocator(), notNullValue());
+        assertThat("First Name Locator", firstName.getLocator(), notNullValue());
+        assertThat("Email Locator", email.getLocator(), notNullValue());
+        assertThat("Dues Locator", dues.getLocator(), notNullValue());
+        assertThat("Website Locator", website.getLocator(), notNullValue());
     }
 
 }

--- a/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/PrimeFacesDashboardPage.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/PrimeFacesDashboardPage.java
@@ -2,8 +2,13 @@ package com.automation.common.ui.app.pageObjects;
 
 import com.taf.automation.ui.support.PageObjectV2;
 import com.taf.automation.ui.support.TestContext;
+import com.thoughtworks.xstream.annotations.XStreamOmitField;
 import org.openqa.selenium.support.FindBy;
 import ru.yandex.qatools.allure.annotations.Step;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  * This class will hold page objects with locators to test that they can be used just like components
@@ -23,6 +28,9 @@ public class PrimeFacesDashboardPage extends PageObjectV2 {
 
     @FindBy(css = "[id$=':weather']")
     private PrimeFacesPanel weatherPanel;
+
+    @XStreamOmitField
+    private PrimeFacesPanel fakePanel;
 
     public PrimeFacesDashboardPage() {
         super();
@@ -92,32 +100,65 @@ public class PrimeFacesDashboardPage extends PageObjectV2 {
         return weatherPanel;
     }
 
+    private PrimeFacesPanel getFakePanel() {
+        if (fakePanel == null) {
+            fakePanel = new PrimeFacesPanel();
+        }
+
+        if (fakePanel.getContext() == null) {
+            fakePanel.initPage(getContext());
+        }
+
+        return fakePanel;
+    }
+
+    @Step("Validate Locators Not Null")
+    public void validateLocatorsNotNull() {
+        // Due to re-factoring the locators may be changed, this is to ensure that they are not null
+        assertThat("Sports Panel Locator", getSportsPanel().getLocator(), notNullValue());
+        assertThat("Lifestyle Panel Locator", getLifestylePanel().getLocator(), notNullValue());
+        assertThat("Politics Panel Locator", getPoliticsPanel().getLocator(), notNullValue());
+        assertThat("Finance Panel Locator", getFinancePanel().getLocator(), notNullValue());
+        assertThat("Weather Panel Locator", getWeatherPanel().getLocator(), notNullValue());
+    }
+
+    @Step("Validate the Fake Panel Locator is Null")
+    public void validateFakePanelLocatorIsNull() {
+        // Due to re-factoring the locators may be changed, this is to ensure that when no locator it remains null
+        assertThat("Fake Panel Locator", getFakePanel().getLocator(), nullValue());
+    }
+
     @Step("Validate Sports Panel")
     public void validateSportsPanel() {
+        getSportsPanel().validateLocatorsNotNull();
         getSportsPanel().validateTitle();
         getSportsPanel().validateContent();
     }
 
     @Step("Validate Lifestyle Panel")
     public void validateLifestylePanel() {
+        getLifestylePanel().validateLocatorsNotNull();
         getLifestylePanel().validateTitle();
         getLifestylePanel().validateContent();
     }
 
     @Step("Validate Politics Panel")
     public void validatePoliticsPanel() {
+        getPoliticsPanel().validateLocatorsNotNull();
         getPoliticsPanel().validateTitle();
         getPoliticsPanel().validateContent();
     }
 
     @Step("Validate Finance Panel")
     public void validateFinancePanel() {
+        getFinancePanel().validateLocatorsNotNull();
         getFinancePanel().validateTitle();
         getFinancePanel().validateContent();
     }
 
     @Step("Validate Weather Panel")
     public void validateWeatherPanel() {
+        getWeatherPanel().validateLocatorsNotNull();
         getWeatherPanel().validateTitle();
         getWeatherPanel().validateContent();
     }

--- a/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/PrimeFacesPanel.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/PrimeFacesPanel.java
@@ -8,6 +8,7 @@ import ui.auto.core.components.WebComponent;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 
 /**
  * Using this class like a component to test functionality of page object with locator which should make all locators
@@ -34,6 +35,13 @@ public class PrimeFacesPanel extends PageObjectV2 {
 
     public String getPanelContent() {
         return panelContent.getText();
+    }
+
+    @Step("Validate Locators Not Null")
+    public void validateLocatorsNotNull() {
+        // Due to re-factoring the locators may be changed, this is to ensure that they are not null
+        assertThat("Title Locator", title.getLocator(), notNullValue());
+        assertThat("Panel Content Locator", panelContent.getLocator(), notNullValue());
     }
 
     @Step("Validate Title")

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/HerokuappDataTableTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/HerokuappDataTableTest.java
@@ -55,6 +55,7 @@ public class HerokuappDataTableTest extends TestNGBase {
         HerokuappDataTablesPage tablesPage = new HerokuappDataTablesPage(getContext());
         List<HerokuappRow> all = tablesPage.getAllRows();
         for (HerokuappRow row : all) {
+            row.validateLocatorsNotNull();
             Table2 actual = new Table2();
             actual.lastName = row.getLastName();
             actual.firstName = row.getFirstName();

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/PrimeFacesDashboardTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/PrimeFacesDashboardTest.java
@@ -22,6 +22,8 @@ public class PrimeFacesDashboardTest extends TestNGBase {
     ) {
         getContext().getDriver().get(url);
         PrimeFacesDashboardDO primeFacesDashboardDO = new PrimeFacesDashboardDO(getContext()).fromResource(dataSet);
+        primeFacesDashboardDO.getPrimeFacesDashboardPage().validateLocatorsNotNull();
+        primeFacesDashboardDO.getPrimeFacesDashboardPage().validateFakePanelLocatorIsNull();
         primeFacesDashboardDO.getPrimeFacesDashboardPage().validateSportsPanel();
         primeFacesDashboardDO.getPrimeFacesDashboardPage().validateLifestylePanel();
         primeFacesDashboardDO.getPrimeFacesDashboardPage().validatePoliticsPanel();


### PR DESCRIPTION
This regression issue was introduced when adding support for page objects with annotation locators.  I have added unit tests to be able to catch the same issue in the future.