### PR TITLE
Re-factor the utility methods that take components to use them instead of elements

### DIFF
--- a/taf/src/main/java/com/taf/automation/ui/support/AssertsUtil.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/AssertsUtil.java
@@ -774,7 +774,7 @@ public class AssertsUtil {
             @Override
             protected boolean matchesSafely(final PageComponent component) {
                 try {
-                    wait.until(ExpectedConditions.visibilityOfElementLocated(component.getLocator()));
+                    wait.until(ExpectedConditionsUtil.displayed(component));
                     return true;
                 } catch (Exception ex) {
                     return false;
@@ -834,7 +834,7 @@ public class AssertsUtil {
             @Override
             protected boolean matchesSafely(final PageComponent component) {
                 try {
-                    wait.until(ExpectedConditions.elementToBeClickable(component.getLocator()));
+                    wait.until(ExpectedConditionsUtil.ready(component));
                     return true;
                 } catch (Exception ex) {
                     return false;
@@ -864,8 +864,8 @@ public class AssertsUtil {
             @Override
             protected boolean matchesSafely(final PageComponent component) {
                 try {
-                    WebElement element = wait.until(ExpectedConditions.presenceOfElementLocated(component.getLocator()));
-                    return element.isEnabled();
+                    wait.until(ExpectedConditionsUtil.enabled(component));
+                    return true;
                 } catch (Exception ex) {
                     return false;
                 }

--- a/taf/src/main/java/com/taf/automation/ui/support/ExpectedConditionsUtil.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/ExpectedConditionsUtil.java
@@ -27,6 +27,7 @@ import java.util.function.Predicate;
 /**
  * This class has custom ExpectedConditions and any new additions to the ExpectedConditions that are later than our current version.<BR>
  */
+@SuppressWarnings("squid:S1168")
 public class ExpectedConditionsUtil {
     private ExpectedConditionsUtil() {
         // Prevent initialization of class as all public methods should be static
@@ -57,13 +58,31 @@ public class ExpectedConditionsUtil {
     }
 
     /**
-     * An expectation for checking WebElement found using the component's locator is ready (enabled &amp; displayed)
+     * An expectation for checking component is ready (enabled &amp; displayed)
      *
-     * @param component - Component used to get locator
-     * @return non-null WebElement when element found using locator is ready else null
+     * @param component - Component used to checked ready (enabled &amp; displayed)
+     * @return non-null WebElement (using component locator) when component is ready else null
      */
     public static ExpectedCondition<WebElement> ready(PageComponent component) {
-        return ready(component.getLocator());
+        return new ExpectedCondition<WebElement>() {
+            @Override
+            public WebElement apply(WebDriver driver) {
+                try {
+                    if (component.isDisplayed() && component.isEnabled()) {
+                        return driver.findElement(component.getLocator());
+                    }
+                } catch (Exception ex) {
+                    //
+                }
+
+                return null;
+            }
+
+            @Override
+            public String toString() {
+                return "component to be ready (enabled & displayed) using locator:  " + component.getLocator();
+            }
+        };
     }
 
     /**
@@ -350,6 +369,7 @@ public class ExpectedConditionsUtil {
      * @param viewPortOnly - true to only take screenshot of the view port, false to attempt full screenshot
      * @return List of attachments
      */
+    @SuppressWarnings({"squid:S1141", "squid:S00112"})
     public static ExpectedCondition<List<Attachment>> takeScreenshot(final String title, final boolean viewPortOnly) {
         return new ExpectedCondition<List<Attachment>>() {
             @Override
@@ -787,6 +807,65 @@ public class ExpectedConditionsUtil {
                 return "url to match any of the regular expressions"
                         + debugInfo
                         + "  Current URL:  " + currentUrl;
+            }
+        };
+    }
+
+    /**
+     * An expectation for checking component is enabled<BR>
+     * <B>Note: </B> If using the framework to get the component, then component must always be displayed
+     * which makes this work the same as the component ready expectation even though there is no explicit check
+     * for displayed<BR>
+     *
+     * @param component - Component used to checked enabled
+     * @return non-null WebElement (using component locator) when component is enabled else null
+     */
+    public static ExpectedCondition<WebElement> enabled(PageComponent component) {
+        return new ExpectedCondition<WebElement>() {
+            @Override
+            public WebElement apply(WebDriver driver) {
+                try {
+                    if (component.isEnabled()) {
+                        return driver.findElement(component.getLocator());
+                    }
+                } catch (Exception ex) {
+                    //
+                }
+
+                return null;
+            }
+
+            @Override
+            public String toString() {
+                return "component to be enabled using locator:  " + component.getLocator();
+            }
+        };
+    }
+
+    /**
+     * An expectation for checking component is displayed
+     *
+     * @param component - Component used to checked displayed
+     * @return non-null WebElement (using component locator) when component is displayed else null
+     */
+    public static ExpectedCondition<WebElement> displayed(PageComponent component) {
+        return new ExpectedCondition<WebElement>() {
+            @Override
+            public WebElement apply(WebDriver driver) {
+                try {
+                    if (component.isDisplayed()) {
+                        return driver.findElement(component.getLocator());
+                    }
+                } catch (Exception ex) {
+                    //
+                }
+
+                return null;
+            }
+
+            @Override
+            public String toString() {
+                return "component to be displayed using locator:  " + component.getLocator();
             }
         };
     }

--- a/taf/src/main/java/com/taf/automation/ui/support/PageObjectV2.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/PageObjectV2.java
@@ -456,16 +456,21 @@ public class PageObjectV2 extends PageObjectModel {
     }
 
     /**
-     * Click component using locator when it is ready.  Method uses a retry policy to handle
+     * Click component when it is ready.  Method uses a retry policy to handle
      * click specific exceptions (ElementClickInterceptedException and ElementNotInteractableException) if they occur
      *
-     * @param component - Component to use locator to click when ready
-     * @return the element that was clicked
+     * @param component - Component to click when ready
+     * @return the element using component locator which in most cases will have been clicked but the component is
+     * controlling the click logic and sometimes this may not be the case based on the component
      */
     protected WebElement click(PageComponent component) {
         assertThat("Click Component", component, notNullValue());
         assertThat("Click Component's Locator", component.getLocator(), notNullValue());
-        return Failsafe.with(Utils.getClickRetryPolicy()).get(() -> Utils.clickWhenReady(component.getLocator()));
+        return Failsafe.with(Utils.getClickRetryPolicy()).get(() -> {
+            WebElement element = Utils.getWebDriverWait().until(ExpectedConditionsUtil.ready(component));
+            component.click();
+            return element;
+        });
     }
 
 }


### PR DESCRIPTION
These utility methods started out just being convenient wrappers for component.getLocator().  However, I have decided to make them use the component methods for checking enabled/displayed/click to handle cases in which there is custom logic in the component.