### PR TITLE
Abstract Component Page Object

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/components/CardExpirationDateFields.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/components/CardExpirationDateFields.java
@@ -1,0 +1,55 @@
+package com.automation.common.ui.app.components;
+
+import com.taf.automation.ui.support.ComponentPO;
+import com.taf.automation.ui.support.TestContext;
+import com.taf.automation.ui.support.Utils;
+import org.openqa.selenium.support.FindBy;
+import ru.yandex.qatools.allure.annotations.Step;
+
+/**
+ * A page object that acts as a component
+ */
+@SuppressWarnings("squid:MaximumInheritanceDepth")
+public class CardExpirationDateFields extends ComponentPO {
+    @FindBy(css = "[name$='ccexp_mm']")
+    private SelectEnhanced month;
+
+    @FindBy(css = "[name$='ccexp_yy']")
+    private SelectEnhanced year;
+
+    public CardExpirationDateFields() {
+        super();
+    }
+
+    public CardExpirationDateFields(TestContext context) {
+        super(context);
+    }
+
+    @Override
+    public boolean hasData() {
+        return Utils.isNotBlank(month) || Utils.isNotBlank(year);
+    }
+
+    @Step("Select Month")
+    public void selectMonth() {
+        setElementValueV2(month);
+    }
+
+    @Step("Select Year")
+    public void selectYear() {
+        setElementValueV2(year);
+    }
+
+    @Override
+    @Step("Fill Card Expiration Date Fields")
+    public void fill() {
+        selectMonth();
+        selectYear();
+    }
+
+    @Override
+    public void validate() {
+        // No actions required to validate
+    }
+
+}

--- a/automation-tests/src/main/java/com/automation/common/ui/app/components/CreditCardFields.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/components/CreditCardFields.java
@@ -1,0 +1,96 @@
+package com.automation.common.ui.app.components;
+
+import com.taf.automation.ui.support.ComponentPO;
+import com.taf.automation.ui.support.TestContext;
+import com.taf.automation.ui.support.Utils;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.openqa.selenium.support.FindBy;
+import ru.yandex.qatools.allure.annotations.Step;
+
+/**
+ * A page object that acts as a component and contains a sub-page object component
+ */
+@SuppressWarnings("squid:MaximumInheritanceDepth")
+public class CreditCardFields extends ComponentPO {
+    @FindBy(css = "select[name$='type']")
+    private SelectEnhanced creditCardType;
+
+    @XStreamAlias("credit-card-number")
+    @FindBy(css = "[name$='ccnumber']")
+    private TextBox creditCardNumber;
+
+    @FindBy(css = "[name$='cvc']")
+    private TextBox cardVerificationCode;
+
+    @XStreamAlias("card-expiration-date")
+    @FindBy(xpath = "//*[select[contains(@name, 'ccexp_yy')] and select[contains(@name, 'ccexp_mm')]]")
+    private CardExpirationDateFields cardExpirationDate;
+
+    @FindBy(css = "[name$='cc_uname']")
+    private TextBox cardUserName;
+
+    public CreditCardFields() {
+        super();
+    }
+
+    public CreditCardFields(TestContext context) {
+        super(context);
+    }
+
+    @Override
+    public boolean hasData() {
+        return Utils.isNotBlank(creditCardType) ||
+                Utils.isNotBlank(creditCardNumber) ||
+                Utils.isNotBlank(cardVerificationCode) ||
+                getCardExpirationDate().hasData() ||
+                Utils.isNotBlank(cardUserName);
+    }
+
+    private CardExpirationDateFields getCardExpirationDate() {
+        if (cardExpirationDate == null) {
+            cardExpirationDate = new CardExpirationDateFields();
+        }
+
+        if (cardExpirationDate.getContext() == null) {
+            cardExpirationDate.initPage(getContext());
+        }
+
+        return cardExpirationDate;
+    }
+
+    @Step("Select Credit Card Type")
+    public void selectCreditCardType() {
+        setElementValueV2(creditCardType);
+    }
+
+    @Step("Enter Credit Card Number")
+    public void enterCreditCardNumber() {
+        setElementValueV2(creditCardNumber);
+    }
+
+    @Step("Enter Card Verification Code")
+    public void enterCardVerificationCode() {
+        setElementValueV2(cardVerificationCode);
+    }
+
+    @Step("Enter Card User Name")
+    public void enterCardUserName() {
+        setElementValueV2(cardUserName);
+    }
+
+    @Override
+    @Step("Fill Card Card Fields")
+    public void fill() {
+        selectCreditCardType();
+        enterCreditCardNumber();
+        enterCardVerificationCode();
+        setElementValueV2(getCardExpirationDate());
+        enterCardUserName();
+    }
+
+    @Override
+    public void validate() {
+        // No actions required to validate
+    }
+
+}

--- a/automation-tests/src/main/java/com/automation/common/ui/app/domainObjects/RoboFormDO.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/domainObjects/RoboFormDO.java
@@ -1,0 +1,33 @@
+package com.automation.common.ui.app.domainObjects;
+
+import com.automation.common.ui.app.pageObjects.RoboFormPage;
+import com.taf.automation.ui.support.DomainObject;
+import com.taf.automation.ui.support.TestContext;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+@SuppressWarnings("squid:MaximumInheritanceDepth")
+@XStreamAlias("robo-form-do")
+public class RoboFormDO extends DomainObject {
+    private RoboFormPage roboFormPage;
+
+    public RoboFormDO() {
+        super();
+    }
+
+    public RoboFormDO(TestContext context) {
+        super(context);
+    }
+
+    public RoboFormPage getRoboFormPage() {
+        if (roboFormPage == null) {
+            roboFormPage = new RoboFormPage();
+        }
+
+        if (roboFormPage.getContext() == null) {
+            roboFormPage.initPage(getContext());
+        }
+
+        return roboFormPage;
+    }
+
+}

--- a/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/RoboFormPage.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/RoboFormPage.java
@@ -1,0 +1,57 @@
+package com.automation.common.ui.app.pageObjects;
+
+import com.automation.common.ui.app.components.CreditCardFields;
+import com.automation.common.ui.app.components.TextBox;
+import com.taf.automation.ui.support.PageObjectV2;
+import com.taf.automation.ui.support.TestContext;
+import org.openqa.selenium.support.FindBy;
+import ru.yandex.qatools.allure.annotations.Step;
+
+public class RoboFormPage extends PageObjectV2 {
+    @FindBy(css = "[name$='frstname']")
+    private TextBox firstName;
+
+    @FindBy(css = "[name$='lastname']")
+    private TextBox lastName;
+
+    private CreditCardFields creditCard;
+
+    public RoboFormPage() {
+        super();
+    }
+
+    public RoboFormPage(TestContext context) {
+        super(context);
+    }
+
+    private CreditCardFields getCreditCard() {
+        if (creditCard == null) {
+            creditCard = new CreditCardFields();
+        }
+
+        if (creditCard.getContext() == null) {
+            creditCard.initPage(getContext());
+        }
+
+        return creditCard;
+    }
+
+
+    @Step("Enter First Name")
+    public void enterFirstName() {
+        setElementValueV2(firstName);
+    }
+
+    @Step("Enter Last Name")
+    public void enterLastName() {
+        setElementValueV2(lastName);
+    }
+
+    @Step("Fill Robo Form Page")
+    public void fill() {
+        enterFirstName();
+        enterLastName();
+        setElementValueV2(getCreditCard());
+    }
+
+}

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/RoboFormTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/RoboFormTest.java
@@ -1,0 +1,28 @@
+package com.automation.common.ui.app.tests;
+
+import com.automation.common.ui.app.domainObjects.RoboFormDO;
+import com.taf.automation.ui.support.testng.TestNGBase;
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+import ru.yandex.qatools.allure.annotations.Features;
+import ru.yandex.qatools.allure.annotations.Severity;
+import ru.yandex.qatools.allure.annotations.Stories;
+import ru.yandex.qatools.allure.model.SeverityLevel;
+
+public class RoboFormTest extends TestNGBase {
+    @Features("Framework")
+    @Stories("Using setElementValueV2 with ComponentPO")
+    @Severity(SeverityLevel.CRITICAL)
+    @Parameters({"url", "data-set"})
+    @Test
+    public void testSetElementValueV2WithComponentPO(
+            @Optional("https://www.roboform.com/filling-test-all-fields") String url,
+            @Optional("data/ui/RoboForm_TestData.xml") String dataSet
+    ) {
+        getContext().getDriver().get(url);
+        RoboFormDO roboFormDO = new RoboFormDO(getContext()).fromResource(dataSet);
+        roboFormDO.getRoboFormPage().fill();
+    }
+
+}

--- a/automation-tests/src/main/resources/data/ui/RoboForm_TestData.xml
+++ b/automation-tests/src/main/resources/data/ui/RoboForm_TestData.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<robo-form-do>
+    <aliases>
+        <test-name>RoboForm Test</test-name>
+    </aliases>
+    <roboFormPage>
+        <firstName>Robo</firstName>
+        <lastName>Form</lastName>
+        <creditCard>
+            <creditCardType>Visa (Preferred)</creditCardType>
+            <credit-card-number>1111222233334444</credit-card-number>
+            <cardVerificationCode>999</cardVerificationCode>
+            <card-expiration-date>
+                <month>01</month>
+                <year>2025</year>
+            </card-expiration-date>
+            <cardUserName>Robo Form</cardUserName>
+        </creditCard>
+    </roboFormPage>
+</robo-form-do>

--- a/automation-tests/src/main/resources/suites/UnversionedTests.xml
+++ b/automation-tests/src/main/resources/suites/UnversionedTests.xml
@@ -125,6 +125,14 @@
         </classes>
     </test>
 
+    <test name="RoboForm Test">
+        <parameter name="url" value="https://www.roboform.com/filling-test-all-fields"/>
+        <parameter name="data-set" value="data/ui/RoboForm_TestData.xml"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.RoboFormTest"/>
+        </classes>
+    </test>
+
     <!--
     <test name="Open Report Test">
         <parameter name="allure-report" value="/target/allure-report"/>

--- a/taf/src/main/java/com/taf/automation/ui/support/ComponentPO.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/ComponentPO.java
@@ -1,0 +1,29 @@
+package com.taf.automation.ui.support;
+
+/**
+ * This is an abstract page object to be used for component page objects
+ */
+public abstract class ComponentPO extends PageObjectV2 {
+    public ComponentPO() {
+        super();
+    }
+
+    public ComponentPO(TestContext context) {
+        super(context);
+    }
+
+    /**
+     * @return true if there is data to be entered else false
+     */
+    public abstract boolean hasData();
+
+    /**
+     * Fill the page object
+     */
+    public abstract void fill();
+
+    /**
+     * Validate the page object was filled properly
+     */
+    public abstract void validate();
+}

--- a/taf/src/main/java/com/taf/automation/ui/support/PageObjectV2.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/PageObjectV2.java
@@ -312,6 +312,36 @@ public class PageObjectV2 extends PageObjectModel {
     }
 
     /**
+     * Fill and Validate Page Object Component
+     *
+     * @param component - Page Object component to fill
+     */
+    protected void setElementValueV2(ComponentPO component) {
+        if (component == null || !component.hasData()) {
+            return;
+        }
+
+        String exception = "";
+        boolean successful;
+
+        try {
+            Failsafe.with(Utils.getWriteValueRetryPolicy()).run(() -> {
+                component.fill();
+                component.validate();
+            });
+            successful = true;
+        } catch (Exception | AssertionError ignore) {
+            // Catch any thrown error or assertion error
+            successful = false;
+            exception = ignore.getMessage();
+        }
+
+        String error = "Unable to fill (" + component.getClass().getSimpleName() + ")"
+                + " & validate before timeout:  " + exception;
+        assertThat(error, successful);
+    }
+
+    /**
      * Set the value of all the pageComponents(if displayed and enabled) to the specified data type.
      * This method will not modify the original values in the data types (initial, data, expected)
      *


### PR DESCRIPTION
Added an abstract page object for use with setElementValueV2.  There already exists a setElementValueV2 for PageComponent and I wanted a similar thing for page objects that are acting like components.  To do this it was necessary to create an abstract page object which page objects that are acting like components would implement.

I have made a test that has page objects as components (and sub-component page object) to validate the design.