### PR TITLE
Add support for user locking

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/UserLockMangerTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/UserLockMangerTest.java
@@ -1,0 +1,40 @@
+package com.automation.common.ui.app.tests;
+
+import com.automation.common.ui.app.domainObjects.JexlExpressionDO;
+import com.taf.automation.locking.UserLockManager;
+import com.taf.automation.ui.support.Helper;
+import com.taf.automation.ui.support.Utils;
+import com.taf.automation.ui.support.testng.TestNGBase;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+import ru.yandex.qatools.allure.annotations.Features;
+import ru.yandex.qatools.allure.annotations.Severity;
+import ru.yandex.qatools.allure.annotations.Stories;
+import ru.yandex.qatools.allure.model.SeverityLevel;
+
+import java.util.Date;
+
+public class UserLockMangerTest extends TestNGBase {
+    @Features("Framework")
+    @Stories("Validate the UserLockManager is functioning properly")
+    @Severity(SeverityLevel.MINOR)
+    @Parameters({"delay", "data-set"})
+    @Test
+    public void testLockingUser(
+            @Optional("1000") String delay,
+            @Optional("data/ui/locking/UserLockManger_User1_TestData.xml") String dataSet
+    ) {
+        new JexlExpressionDO(getContext()).fromResource(dataSet);
+        Helper.log("" + new Date() + " User (" + UserLockManager.getInstance().getUser() + ") sleeping for " + delay, true);
+        Utils.sleep(NumberUtils.toInt(delay, 1000));
+    }
+
+    @AfterTest(alwaysRun = true)
+    private void unlockUser() {
+        UserLockManager.getInstance().unlock();
+    }
+
+}

--- a/automation-tests/src/main/resources/data/ui/locking/UserLockManger_RandomizedUser_TestData.xml
+++ b/automation-tests/src/main/resources/data/ui/locking/UserLockManger_RandomizedUser_TestData.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<jexl-expression-do>
+    <aliases>
+        <randomLetters>$[ALPHANUMERIC('{a}{b}{c}{d}{e}', 'null')]</randomLetters>
+        <randomNumbers>$[NUMBER('000','200,999')]</randomNumbers>
+        <user>${randomLetters+randomNumbers}</user>
+        <thread-id>${userLockManager.lock(user)}</thread-id>
+    </aliases>
+    <someField>User=${user}</someField>
+    <anotherField>Thread Id=${thread-id}</anotherField>
+</jexl-expression-do>

--- a/automation-tests/src/main/resources/data/ui/locking/UserLockManger_User1_TestData.xml
+++ b/automation-tests/src/main/resources/data/ui/locking/UserLockManger_User1_TestData.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<jexl-expression-do>
+    <aliases>
+        <user>aaa</user>
+        <thread-id>${userLockManager.lock(user)}</thread-id>
+    </aliases>
+    <someField>User=${user}</someField>
+    <anotherField>Thread Id=${thread-id}</anotherField>
+</jexl-expression-do>

--- a/automation-tests/src/main/resources/data/ui/locking/UserLockManger_User2_TestData.xml
+++ b/automation-tests/src/main/resources/data/ui/locking/UserLockManger_User2_TestData.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<jexl-expression-do>
+    <aliases>
+        <user>bbb</user>
+        <thread-id>${userLockManager.lock(user)}</thread-id>
+    </aliases>
+    <someField>User=${user}</someField>
+    <anotherField>Thread Id=${thread-id}</anotherField>
+</jexl-expression-do>

--- a/automation-tests/src/main/resources/suites/ui/MultiUserLocking_Suite.xml
+++ b/automation-tests/src/main/resources/suites/ui/MultiUserLocking_Suite.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="Multi User Locking Suite"  verbose="1" parallel="tests" thread-count="5" data-provider-thread-count="5">
+
+    <test name="User Lock Manger Test #1">
+        <parameter name="delay" value="2000"/>
+        <parameter name="data-set" value="data/ui/locking/UserLockManger_User1_TestData.xml"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.UserLockMangerTest"/>
+        </classes>
+    </test>
+
+    <test name="User Lock Manger Test #2">
+        <parameter name="delay" value="2000"/>
+        <parameter name="data-set" value="data/ui/locking/UserLockManger_User2_TestData.xml"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.UserLockMangerTest"/>
+        </classes>
+    </test>
+
+    <test name="User Lock Manger Test #3">
+        <parameter name="delay" value="2000"/>
+        <parameter name="data-set" value="data/ui/locking/UserLockManger_User1_TestData.xml"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.UserLockMangerTest"/>
+        </classes>
+    </test>
+
+    <test name="User Lock Manger Test #4">
+        <parameter name="delay" value="2000"/>
+        <parameter name="data-set" value="data/ui/locking/UserLockManger_User2_TestData.xml"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.UserLockMangerTest"/>
+        </classes>
+    </test>
+
+    <test name="User Lock Manger Test #5">
+        <parameter name="delay" value="2000"/>
+        <parameter name="data-set" value="data/ui/locking/UserLockManger_RandomizedUser_TestData.xml"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.UserLockMangerTest"/>
+        </classes>
+    </test>
+
+    <test name="User Lock Manger Test #6">
+        <parameter name="delay" value="2000"/>
+        <parameter name="data-set" value="data/ui/locking/UserLockManger_User1_TestData.xml"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.UserLockMangerTest"/>
+        </classes>
+    </test>
+
+    <test name="User Lock Manger Test #7">
+        <parameter name="delay" value="2000"/>
+        <parameter name="data-set" value="data/ui/locking/UserLockManger_User2_TestData.xml"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.UserLockMangerTest"/>
+        </classes>
+    </test>
+
+    <test name="User Lock Manger Test #8">
+        <parameter name="delay" value="2000"/>
+        <parameter name="data-set" value="data/ui/locking/UserLockManger_User1_TestData.xml"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.UserLockMangerTest"/>
+        </classes>
+    </test>
+
+    <test name="User Lock Manger Test #9">
+        <parameter name="delay" value="2000"/>
+        <parameter name="data-set" value="data/ui/locking/UserLockManger_User2_TestData.xml"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.UserLockMangerTest"/>
+        </classes>
+    </test>
+
+    <test name="User Lock Manger Test #10">
+        <parameter name="delay" value="2000"/>
+        <parameter name="data-set" value="data/ui/locking/UserLockManger_RandomizedUser_TestData.xml"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.UserLockMangerTest"/>
+        </classes>
+    </test>
+
+</suite>

--- a/automation-tests/src/main/resources/suites/ui/SingleUserLocking_Suite.xml
+++ b/automation-tests/src/main/resources/suites/ui/SingleUserLocking_Suite.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="Single User Locking Suite"  verbose="1" parallel="tests" thread-count="5" data-provider-thread-count="5">
+
+    <test name="User Lock Manger Test #1">
+        <parameter name="delay" value="2000"/>
+        <parameter name="data-set" value="data/ui/locking/UserLockManger_User1_TestData.xml"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.UserLockMangerTest"/>
+        </classes>
+    </test>
+
+    <test name="User Lock Manger Test #2">
+        <parameter name="delay" value="2000"/>
+        <parameter name="data-set" value="data/ui/locking/UserLockManger_User1_TestData.xml"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.UserLockMangerTest"/>
+        </classes>
+    </test>
+
+    <test name="User Lock Manger Test #3">
+        <parameter name="delay" value="2000"/>
+        <parameter name="data-set" value="data/ui/locking/UserLockManger_User1_TestData.xml"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.UserLockMangerTest"/>
+        </classes>
+    </test>
+
+    <test name="User Lock Manger Test #4">
+        <parameter name="delay" value="2000"/>
+        <parameter name="data-set" value="data/ui/locking/UserLockManger_User1_TestData.xml"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.UserLockMangerTest"/>
+        </classes>
+    </test>
+
+    <test name="User Lock Manger Test #5">
+        <parameter name="delay" value="2000"/>
+        <parameter name="data-set" value="data/ui/locking/UserLockManger_User1_TestData.xml"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.UserLockMangerTest"/>
+        </classes>
+    </test>
+
+</suite>

--- a/taf/src/main/java/com/taf/automation/locking/UserLockManager.java
+++ b/taf/src/main/java/com/taf/automation/locking/UserLockManager.java
@@ -1,0 +1,111 @@
+package com.taf.automation.locking;
+
+import org.apache.commons.lang3.ObjectUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Ensures exclusive use of registered users
+ */
+public class UserLockManager {
+    private static final ReentrantLock action = new ReentrantLock();
+    private static final Condition userRemoved = action.newCondition();
+    private static final Map<String, Long> storedUsers = new HashMap<>();
+    private static final Map<String, ReentrantLock> pendingUsers = new HashMap<>();
+
+    private UserLockManager() {
+        //
+    }
+
+    private static class LazyHolder {
+        private static final UserLockManager INSTANCE = new UserLockManager();
+    }
+
+    public static UserLockManager getInstance() {
+        return UserLockManager.LazyHolder.INSTANCE;
+    }
+
+    public Long lock(String user) {
+        return lock(user, Thread.currentThread().getId());
+    }
+
+    public Long lock(String user, Long threadId) {
+        action.lock();
+        pendingUsers.putIfAbsent(user, new ReentrantLock());
+        action.unlock();
+
+        pendingUsers.get(user).lock();
+        while (storedUsers.containsKey(user)) {
+            try {
+                userRemoved.await();
+            } catch (Exception ex) {
+                //
+            }
+        }
+
+        action.lock();
+        storedUsers.put(user, threadId);
+        pendingUsers.get(user).unlock();
+        action.unlock();
+
+        return threadId;
+    }
+
+    public boolean unlock() {
+        return unlock(Thread.currentThread().getId());
+    }
+
+    public boolean unlock(Long threadId) {
+        action.lock();
+        try {
+            boolean result = storedUsers.values().removeIf(item -> item.equals(threadId));
+            if (result) {
+                userRemoved.signalAll();
+            }
+
+            return result;
+        } finally {
+            action.unlock();
+        }
+    }
+
+    public Long unlock(String user) {
+        action.lock();
+        try {
+            Long result = storedUsers.remove(user);
+            userRemoved.signalAll();
+            return result;
+        } finally {
+            action.unlock();
+        }
+    }
+
+    /**
+     * Get the user locked by the current thread
+     *
+     * @return null if no user being locked, else user
+     */
+    public String getUser() {
+        return getUser(Thread.currentThread().getId());
+    }
+
+    /**
+     * Get the user locked by the thread
+     *
+     * @param threadId - Thread Id to get the user being locked by the thread
+     * @return null if no user being locked, else user
+     */
+    public String getUser(Long threadId) {
+        for (Map.Entry<String, Long> item : storedUsers.entrySet()) {
+            if (ObjectUtils.compare(item.getValue(), threadId) == 0) {
+                return item.getKey();
+            }
+        }
+
+        return null;
+    }
+
+}

--- a/taf/src/main/java/com/taf/automation/ui/support/DomainObject.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/DomainObject.java
@@ -1,5 +1,6 @@
 package com.taf.automation.ui.support;
 
+import com.taf.automation.locking.UserLockManager;
 import com.taf.automation.ui.support.csv.CsvTestData;
 import com.thoughtworks.xstream.XStream;
 import datainstiller.data.DataAliases;
@@ -26,6 +27,7 @@ public class DomainObject extends DomainObjectModel {
     protected void initJexlContext(JexlContext jexlContext) {
         super.initJexlContext(jexlContext);
         jexlContext.set("crypto", new CryptoUtils());
+        jexlContext.set("userLockManager", UserLockManager.getInstance());
     }
 
     /**


### PR DESCRIPTION
You can lock a user using JEXL or within the test.  However, you must always unlock the user after the test regardless of the result.  If the user is not unlocked, then any tests attempting to acquire the user will never start and the automation run will indefinitely.