### PR TITLE
Fix Duplicate Report Entries

### DIFF
--- a/taf/src/main/java/com/taf/automation/api/ApiDomainObject.java
+++ b/taf/src/main/java/com/taf/automation/api/ApiDomainObject.java
@@ -75,8 +75,10 @@ public class ApiDomainObject extends DataPersistenceV2 {
 
         // When resolve alias is true, then the aliases will be made null after loading
         // as such get the aliases before loading
+        useAliasesXstreamFlag();
         T temp = super.fromResource(useResourceFile, false);
         DataAliases aliases = temp.getDataAliases();
+        useNormalXstreamFlag();
 
         T dataSet = super.fromResource(useResourceFile, true);
         DomainObjectUtils.overwriteTestParameters(aliases);

--- a/taf/src/main/java/com/taf/automation/ui/support/DataAliasesConverterV2.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/DataAliasesConverterV2.java
@@ -12,6 +12,8 @@ import org.apache.commons.jexl3.JexlBuilder;
 import org.apache.commons.jexl3.JexlContext;
 import org.apache.commons.jexl3.JxltEngine;
 import org.apache.commons.jexl3.MapContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -21,6 +23,7 @@ import java.util.regex.Pattern;
  * This is based on the DataAliasesConverter but there are changes to allow for custom generators to be used
  */
 public class DataAliasesConverterV2 implements Converter {
+    private static final Logger LOG = LoggerFactory.getLogger(DataAliasesConverterV2.class);
     private JexlContext jexlContext;
 
     public DataAliasesConverterV2(JexlContext jexlContext) {
@@ -79,7 +82,7 @@ public class DataAliasesConverterV2 implements Converter {
                     objValue = expr.evaluate(jexlContext);
                     value = objValue.toString();
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    LOG.warn(e.getMessage());
                 }
             }
 

--- a/taf/src/main/java/com/taf/automation/ui/support/DataPersistenceV2.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/DataPersistenceV2.java
@@ -1,6 +1,8 @@
 package com.taf.automation.ui.support;
 
 import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.annotations.XStreamOmitField;
+import com.thoughtworks.xstream.converters.extended.ISO8601GregorianCalendarConverter;
 import datainstiller.data.DataGenerator;
 import datainstiller.data.DataPersistence;
 import org.apache.commons.jexl3.JexlContext;
@@ -14,8 +16,19 @@ import static org.hamcrest.MatcherAssert.assertThat;
  * unusual to use xml namespaces (i.e. the attribute "xmlns".)
  */
 public abstract class DataPersistenceV2 extends DataPersistence {
+    @XStreamOmitField
+    private boolean useXstreamForAliases;
+
     protected DataPersistenceV2() {
         //
+    }
+
+    protected void useAliasesXstreamFlag() {
+        useXstreamForAliases = true;
+    }
+
+    protected void useNormalXstreamFlag() {
+        useXstreamForAliases = false;
     }
 
     /**
@@ -45,7 +58,15 @@ public abstract class DataPersistenceV2 extends DataPersistence {
 
     @Override
     public XStream getXstream() {
-        XStream xStream = DataInstillerUtils.getXStream(getJexlContext());
+        XStream xStream;
+        if (useXstreamForAliases) {
+            xStream = new XStream();
+            xStream.registerConverter(new DataAliasesConverterV2(null));
+            xStream.registerConverter(new ISO8601GregorianCalendarConverter());
+        } else {
+            xStream = DataInstillerUtils.getXStream(getJexlContext());
+        }
+
         xStream.processAnnotations(this.getClass());
         return xStream;
     }


### PR DESCRIPTION
A side effect of loading the data file twice for API is that duplicate report entries will appear if the JEXL Expressions call methods that use the annotation step.

This fixes the issue but there is a side-effect of extra warnings being written to the console for JEXL Expressions in the API domain object.  Example:
```
WARN com.taf.automation.ui.support.DataAliasesConverterV2 - com.taf.automation.ui.support.DataAliasesConverterV2.unmarshal@1:1![0,26]: 'crypto.decrypt(encApiHelp)' failed to evaluate '${crypto.decrypt(encApiHelp)}'
```