### PR TITLE
Upgrade to Failsafe 2.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <java.mail.version>1.4.1</java.mail.version>
         <jsoup.version>1.8.3</jsoup.version>
         <jsch.version>0.1.53</jsch.version>
-        <failsafe.version>1.0.4</failsafe.version>
+        <failsafe.version>2.3.4</failsafe.version>
         <springframework.version>4.2.4.RELEASE</springframework.version>
         <mysql-connector.version>5.1.38</mysql-connector.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/taf/src/main/java/com/taf/automation/ui/support/GenericRow.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/GenericRow.java
@@ -107,7 +107,7 @@ public class GenericRow extends PageObjectV2 {
             return true;
         }
 
-        return StringUtils.defaultString(Failsafe.with(Utils.getRetryPolicy(0)).get(actionToScrapeData)).matches(regex);
+        return StringUtils.defaultString(Failsafe.with(Utils.getRetryPolicy(0)).get(actionToScrapeData::call)).matches(regex);
     }
 
 }

--- a/taf/src/main/java/com/taf/automation/ui/support/conditional/LambdaExpressionMatch.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/conditional/LambdaExpressionMatch.java
@@ -35,7 +35,7 @@ public class LambdaExpressionMatch implements Match {
         }
 
         try {
-            if (Failsafe.with(Utils.getRetryPolicy(0)).get(getLambda())) {
+            if (Failsafe.with(Utils.getRetryPolicy(0)).get(getLambda()::call)) {
                 resultInfo = new ResultInfo();
                 resultInfo.setMatch(true);
                 resultInfo.setCriteriaType(criteria.getCriteriaType());


### PR DESCRIPTION
There are a few changes to the library that affect the usage in the framework
- Suppliers are now used instead of Callables.  This means that when you have a Callable variable it cannot be directly used with the get method 
```
Failsafe.with(Utils.getRetryPolicy(0)).get(actionToScrapeData))
```
instead it needs to be invoked
```
Failsafe.with(Utils.getRetryPolicy(0)).get(actionToScrapeData::call))
```
- Policy implementations now take a type parameter R that represents the expected result type.
- The retryOn, retryIf, and retryWhen methods have been replace with handleOn, etc.
- RetryPolicy now has 3 max attempts by default.
- Some of the time related policy configurations have been changed to use Duration instead of long + TimeUnit

This means that creation of a RetryPolicy has changed slightly from
```
    public static RetryPolicy getPollingRetryPolicy(int maxDurationInSeconds) {
        return new RetryPolicy()
                .retryOn(Exception.class, AssertionError.class)
                .withMaxDuration(maxDurationInSeconds, TimeUnit.SECONDS)
                .withDelay(1, TimeUnit.SECONDS);
    }
```
to
```
    public static RetryPolicy<Object> getPollingRetryPolicy(int maxDurationInSeconds) {
        return new RetryPolicy<>()
                .handle(Exception.class, AssertionError.class) // Method name change
                .withMaxRetries(-1) // Override default value
                .withMaxDuration(Duration.ofSeconds(maxDurationInSeconds)) // Method signature change
                .withDelay(Duration.ofSeconds(1));
    }
```
For the full list of changes, see https://github.com/jhalterman/failsafe/blob/master/CHANGES.md#20
