### PR TITLE
Class to store variables prior to loading domain object from resource

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/domainObjects/JexlExpressionDO.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/domainObjects/JexlExpressionDO.java
@@ -12,6 +12,8 @@ import ui.auto.core.data.DataTypes;
 public class JexlExpressionDO extends DomainObject {
     private AliasedString someField;
     private AliasedString anotherField;
+    private AliasedString extraField1;
+    private AliasedString extraField2;
 
     public JexlExpressionDO() {
         super();
@@ -50,6 +52,30 @@ public class JexlExpressionDO extends DomainObject {
 
     public String getAnotherFieldInitial() {
         return anotherField.getData(DataTypes.Initial, true);
+    }
+
+    public String getExtraField1() {
+        return extraField1.getData();
+    }
+
+    public String getExtraField1Expected() {
+        return extraField1.getData(DataTypes.Expected, true);
+    }
+
+    public String getExtraField1Initial() {
+        return extraField1.getData(DataTypes.Initial, true);
+    }
+
+    public String getExtraField2() {
+        return extraField2.getData();
+    }
+
+    public String getExtraField2Expected() {
+        return extraField2.getData(DataTypes.Expected, true);
+    }
+
+    public String getExtraField2Initial() {
+        return extraField2.getData(DataTypes.Initial, true);
     }
 
 }

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/JexlExpressionTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/JexlExpressionTest.java
@@ -1,6 +1,8 @@
 package com.automation.common.ui.app.tests;
 
 import com.automation.common.ui.app.domainObjects.JexlExpressionDO;
+import com.taf.automation.ui.support.Lookup;
+import com.taf.automation.ui.support.Rand;
 import com.taf.automation.ui.support.testng.TestNGBase;
 import org.testng.annotations.Optional;
 import org.testng.annotations.Parameters;
@@ -22,7 +24,7 @@ import static org.hamcrest.Matchers.not;
 public class JexlExpressionTest extends TestNGBase {
     private static final List<String> jexlVariables = Arrays.asList(
             "str1", "str2", "RANDOM_DATE", "RANDOM_US_ADDRESS",
-            "ALPHANUMERIC", "crypto"
+            "ALPHANUMERIC", "crypto", "lookup"
     );
     private static final String GENERIC = "Variable %s was not evaluated by Jexl for %s";
 
@@ -32,12 +34,18 @@ public class JexlExpressionTest extends TestNGBase {
     @Parameters("data-set")
     @Test
     public void testJexlExpresionEvaluation(@Optional("data/ui/JexlExpresion_TestData.xml") String dataSet) {
+        Lookup.getInstance().put("beforeLoadResource1", Rand.alphanumeric(5, 10));
+        Lookup.getInstance().put("beforeLoadResource2", Rand.alphanumeric(5, 10));
         JexlExpressionDO jexlDO = new JexlExpressionDO(getContext()).fromResource(dataSet);
         validateFieldValue("Some Field", jexlDO.getSomeField(), jexlDO.getSomeFieldExpected());
         validateFieldValue("Another Field", jexlDO.getAnotherField(), jexlDO.getAnotherFieldExpected());
+        validateFieldValue("Extra Field 1", jexlDO.getExtraField1(), jexlDO.getExtraField1Expected());
+        validateFieldValue("Extra Field 2", jexlDO.getExtraField2(), jexlDO.getExtraField2Expected());
         for (String var : jexlVariables) {
             validateField(var, jexlDO.getSomeField(), jexlDO.getSomeFieldExpected(), jexlDO.getSomeFieldInitial());
             validateField(var, jexlDO.getAnotherField(), jexlDO.getAnotherFieldExpected(), jexlDO.getAnotherFieldInitial());
+            validateField(var, jexlDO.getExtraField1(), jexlDO.getExtraField1Expected(), jexlDO.getExtraField1Initial());
+            validateField(var, jexlDO.getExtraField2(), jexlDO.getExtraField2Expected(), jexlDO.getExtraField2Initial());
         }
     }
 

--- a/automation-tests/src/main/resources/data/ui/JexlExpresion_TestData.xml
+++ b/automation-tests/src/main/resources/data/ui/JexlExpresion_TestData.xml
@@ -7,6 +7,12 @@
         <var2>${str2}</var2>
         <var3>${str1 + " " + str2}</var3>
         <var4>${str2 + " " + str1}</var4>
+        <!-- Remove is only necessary if running the same test multiple times in the same thread -->
+        <var5>${lookup.remove("runtime001").append("runtime001", "12345").append("runtime001", "xyz").get("runtime001")}</var5>
+        <var6>12345xyz</var6>
+        <var7>${lookup.get("beforeLoadResource1") + lookup.get("beforeLoadResource2")}</var7>
+        <var8>${lookup.get("beforeLoadResource1")}</var8>
+        <var9>${lookup.get("beforeLoadResource2")}</var9>
         <RandomDateGenerator>$[RANDOM_DATE('yyyy-MM-dd','365|720')]</RandomDateGenerator>
         <RandomRealUSAddressGenerator>$[RANDOM_US_ADDRESS('{#} {C} {S} {Z} {U} {P}','')]</RandomRealUSAddressGenerator>
         <orgPass>$[ALPHANUMERIC('{a}{b}{c}{d}{e}', 'null')]</orgPass>
@@ -15,4 +21,6 @@
     </aliases>
     <someField initial="${var4} ${RandomDateGenerator} ${RandomRealUSAddressGenerator}" expected="${var1} ${var2}">${var3}</someField>
     <anotherField initial="${encPass}" expected="${decPass}">${orgPass}</anotherField>
+    <extraField1 initial="${var5}" expected="${var6}">${var5}</extraField1>
+    <extraField2 initial="${var7}" expected="${var7}">${var8}${var9}</extraField2>
 </jexl-expression-do>

--- a/taf/src/main/java/com/taf/automation/api/ApiDomainObject.java
+++ b/taf/src/main/java/com/taf/automation/api/ApiDomainObject.java
@@ -4,10 +4,12 @@ import com.taf.automation.api.clients.ApiClient;
 import com.taf.automation.api.clients.ApiLoginSession;
 import com.taf.automation.api.clients.UserLogin;
 import com.taf.automation.api.rest.GenericHttpResponse;
+import com.taf.automation.locking.UserLockManager;
 import com.taf.automation.ui.support.CryptoUtils;
 import com.taf.automation.ui.support.DataPersistenceV2;
 import com.taf.automation.ui.support.DomainObjectUtils;
 import com.taf.automation.ui.support.Helper;
+import com.taf.automation.ui.support.Lookup;
 import com.taf.automation.ui.support.TestProperties;
 import com.taf.automation.ui.support.Utils;
 import com.taf.automation.ui.support.converters.Credentials;
@@ -53,6 +55,8 @@ public class ApiDomainObject extends DataPersistenceV2 {
     @Override
     protected void initJexlContext(JexlContext jexlContext) {
         jexlContext.set("crypto", new CryptoUtils());
+        jexlContext.set("userLockManager", UserLockManager.getInstance());
+        jexlContext.set("lookup", Lookup.getInstance());
     }
 
     @Override

--- a/taf/src/main/java/com/taf/automation/ui/support/DomainObject.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/DomainObject.java
@@ -28,6 +28,7 @@ public class DomainObject extends DomainObjectModel {
         super.initJexlContext(jexlContext);
         jexlContext.set("crypto", new CryptoUtils());
         jexlContext.set("userLockManager", UserLockManager.getInstance());
+        jexlContext.set("lookup", Lookup.getInstance());
     }
 
     /**

--- a/taf/src/main/java/com/taf/automation/ui/support/Lookup.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/Lookup.java
@@ -1,0 +1,63 @@
+package com.taf.automation.ui.support;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Stores variables that can be retrieved later (from JEXL expressions)
+ */
+public class Lookup {
+    private final ThreadLocal<Map<String, String>> storedVariables = ThreadLocal.withInitial(HashMap::new);
+
+    private Lookup() {
+        //
+    }
+
+    private static class LazyHolder {
+        private static final Lookup INSTANCE = new Lookup();
+    }
+
+    public static Lookup getInstance() {
+        return Lookup.LazyHolder.INSTANCE;
+    }
+
+    private Map<String, String> getStoredVariables() {
+        return storedVariables.get();
+    }
+
+    /**
+     * Unloads the thread local variable to prevent sonar violation
+     * "ThreadLocal" variables should be cleaned up when no longer used.<BR>
+     * <B>Note: </B> This should not really be needed to be called but you would probably call it after a test.
+     *
+     * @return Lookup
+     */
+    public Lookup unload() {
+        storedVariables.remove();
+        return this;
+    }
+
+    public Lookup put(String key, String value) {
+        getStoredVariables().put(key, value);
+        return this;
+    }
+
+    public String get(String key) {
+        return getStoredVariables().get(key);
+    }
+
+    public String getOrDefault(String key, String defaultValue) {
+        return getStoredVariables().getOrDefault(key, defaultValue);
+    }
+
+    public Lookup append(String key, String value) {
+        getStoredVariables().put(key, getOrDefault(key, "") + value);
+        return this;
+    }
+
+    public Lookup remove(String key) {
+        getStoredVariables().remove(key);
+        return this;
+    }
+
+}

--- a/taf/src/main/java/com/taf/automation/ui/support/Lookup.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/Lookup.java
@@ -7,7 +7,7 @@ import java.util.Map;
  * Stores variables that can be retrieved later (from JEXL expressions)
  */
 public class Lookup {
-    private final ThreadLocal<Map<String, String>> storedVariables = ThreadLocal.withInitial(HashMap::new);
+    private static final ThreadLocal<Map<String, String>> storedVariables = ThreadLocal.withInitial(HashMap::new);
 
     private Lookup() {
         //
@@ -21,7 +21,7 @@ public class Lookup {
         return Lookup.LazyHolder.INSTANCE;
     }
 
-    private Map<String, String> getStoredVariables() {
+    private static Map<String, String> getStoredVariables() {
         return storedVariables.get();
     }
 

--- a/taf/src/main/java/com/taf/automation/ui/support/Rand.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/Rand.java
@@ -62,6 +62,15 @@ public class Rand {
     }
 
     /**
+     * Get Instance for use with JEXL Expressions
+     *
+     * @return Rand
+     */
+    public static Rand getInstance() {
+        return new Rand();
+    }
+
+    /**
      * Gets the default special characters.
      *
      * @return SPECIAL


### PR DESCRIPTION
On a rare occasion, it might be necessary to scrape information from the GUI of an application (or possibly an API) and this information to be referenced in the test data of another domain object.

For example, suppose you are testing a streaming service and you want to verify notification about the trial is ending.  This would require the application system clock moving and you probably have an environment in which to do this and the current time in that environment is something other than the current day.  Your test data would to be able to reference the current system time which would need to be scraped from some where.

With the Lookup, you can scrape the current system time (which probably is in the future) and save it for use later when you actually load the domain object from the resource (test data file.)