### PR TITLE
Add IMAP support & modify TestProperties for mail properties

### DIFF
--- a/taf/src/main/java/com/taf/automation/ui/support/TestProperties.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/TestProperties.java
@@ -252,8 +252,11 @@ public class TestProperties {
     @Property("documentation.mode")
     private boolean documentationMode = false;
 
-    @Property("mail.pop3.server")
+    @Property("mail.server")
     private String mailServer;
+
+    @Property("mail.server.port")
+    private int mailServerPort;
 
     @Property("mail.password")
     @HideInReport
@@ -697,6 +700,10 @@ public class TestProperties {
 
     public String getMailServer() {
         return mailServer;
+    }
+
+    public int getMailServerPort() {
+        return mailServerPort;
     }
 
     public String getMailPassword() {


### PR DESCRIPTION
Re-factoring of TestProperties to use common property for pop3 & IMAP (or any other format in future.)  Re-factoring Pop3Mail to support non-default ports and general formatting.

**Note**:  In my testing, I found that flagging a message as deleted will immediately delete it and it would not be added to the list of results.  It was necessary to set the flag as deleted after the message found using search was added to the list.  I have kept **folder.close(deleteEmails)** but IMAP does not respect this, once it is deleted it is gone.