### PR TITLE
Fix close browser issue

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/ChangeBrowserTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/ChangeBrowserTest.java
@@ -16,29 +16,38 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
 public class ChangeBrowserTest extends TestNGBase {
-    private static final String GOOGLE = "google";
-    private static final String TSN = "tsn.ca";
+    private static final String SITE_1 = "https://www.google.ca";
+    private static final String SITE_1_VALIDATION = "google";
+    private static final String SITE_2 = "https://the-internet.herokuapp.com/broken_images";
+    private static final String SITE_2_VALIDATION = "the-internet.herokuapp.com";
+    private static final WebDriverTypeEnum CHANGE_BROWSER = WebDriverTypeEnum.FIREFOX;
+
+    /**
+     * The CHANGE_BROWSER should always be the same.  However, for testing purposes to see a failure change
+     * the EXPECTED_BROWSER to something different.
+     */
+    private static final WebDriverTypeEnum EXPECTED_BROWSER = WebDriverTypeEnum.FIREFOX;
 
     @Features("Framework")
     @Stories("Verify changing of browsers")
     @Severity(SeverityLevel.CRITICAL)
     @Test
     public void performTest() {
-        getContext().getDriver().get("https://www.google.ca");
-        assertThat("Initial Context URL", getContext().getDriver().getCurrentUrl(), containsString(GOOGLE));
+        getContext().getDriver().get(SITE_1);
+        assertThat("Initial Context URL", getContext().getDriver().getCurrentUrl(), containsString(SITE_1_VALIDATION));
 
         Utils.restoreBrowser();
-        assertThat("Restore Browser No Effect", getContext().getDriver().getCurrentUrl(), containsString(GOOGLE));
+        assertThat("Restore Browser No Effect", getContext().getDriver().getCurrentUrl(), containsString(SITE_1_VALIDATION));
         assertThat("Test Properties No Effect", Utils.getStoredTestProperties().getBrowserType(), equalTo(TestProperties.getInstance().getBrowserType()));
 
-        Utils.changeBrowser(WebDriverTypeEnum.CHROME);
-        getContext().getDriver().get("https://www.tsn.ca");
-        assertThat("Changed Context URL", getContext().getDriver().getCurrentUrl(), containsString(TSN));
-        assertThat("Changed Test Properties", Utils.getStoredTestProperties().getBrowserType(), equalTo(WebDriverTypeEnum.CHROME));
+        Utils.changeBrowser(CHANGE_BROWSER);
+        getContext().getDriver().get(SITE_2);
+        assertThat("Changed Context URL", getContext().getDriver().getCurrentUrl(), containsString(SITE_2_VALIDATION));
+        assertThat("Changed Test Properties", Utils.getStoredTestProperties().getBrowserType(), equalTo(EXPECTED_BROWSER));
 
         Utils.restoreBrowser();
-        assertThat("Restored Context URL Diff", getContext().getDriver().getCurrentUrl(), not(containsString(TSN)));
-        assertThat("Restored Context URL Same", getContext().getDriver().getCurrentUrl(), containsString(GOOGLE));
+        assertThat("Restored Context URL Diff", getContext().getDriver().getCurrentUrl(), not(containsString(SITE_2_VALIDATION)));
+        assertThat("Restored Context URL Same", getContext().getDriver().getCurrentUrl(), containsString(SITE_1_VALIDATION));
         assertThat("Restored Test Properties", Utils.getStoredTestProperties().getBrowserType(), equalTo(TestProperties.getInstance().getBrowserType()));
     }
 

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/ChangeBrowserTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/ChangeBrowserTest.java
@@ -20,13 +20,13 @@ public class ChangeBrowserTest extends TestNGBase {
     private static final String SITE_1_VALIDATION = "google";
     private static final String SITE_2 = "https://the-internet.herokuapp.com/broken_images";
     private static final String SITE_2_VALIDATION = "the-internet.herokuapp.com";
-    private static final WebDriverTypeEnum CHANGE_BROWSER = WebDriverTypeEnum.FIREFOX;
+    private static final WebDriverTypeEnum CHANGE_BROWSER = TestProperties.getInstance().getBrowserType();
 
     /**
      * The CHANGE_BROWSER should always be the same.  However, for testing purposes to see a failure change
      * the EXPECTED_BROWSER to something different.
      */
-    private static final WebDriverTypeEnum EXPECTED_BROWSER = WebDriverTypeEnum.FIREFOX;
+    private static final WebDriverTypeEnum EXPECTED_BROWSER = TestProperties.getInstance().getBrowserType();
 
     @Features("Framework")
     @Stories("Verify changing of browsers")

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/RetryTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/RetryTest.java
@@ -4,12 +4,19 @@ import com.taf.automation.ui.support.testng.Retry;
 import com.taf.automation.ui.support.testng.TestNGBase;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.testng.annotations.Test;
+import ru.yandex.qatools.allure.annotations.Features;
+import ru.yandex.qatools.allure.annotations.Severity;
+import ru.yandex.qatools.allure.annotations.Stories;
+import ru.yandex.qatools.allure.model.SeverityLevel;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class RetryTest extends TestNGBase {
     private MutableInt attempt;
 
+    @Features("Framework")
+    @Stories("Validate the retry functionality")
+    @Severity(SeverityLevel.CRITICAL)
     @Test
     @Retry
     public void testThatPassesOnRetry() {

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/SameThreadTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/SameThreadTest.java
@@ -9,7 +9,11 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
+import ru.yandex.qatools.allure.annotations.Features;
+import ru.yandex.qatools.allure.annotations.Severity;
 import ru.yandex.qatools.allure.annotations.Step;
+import ru.yandex.qatools.allure.annotations.Stories;
+import ru.yandex.qatools.allure.model.SeverityLevel;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -28,6 +32,9 @@ public class SameThreadTest extends TestNGBase {
         expectedThreadId = Thread.currentThread().getId();
     }
 
+    @Features("Framework")
+    @Stories("Validate the same thread is being used")
+    @Severity(SeverityLevel.CRITICAL)
     @Test
     public void performTest() {
         Helper.log("Running Test", true);

--- a/automation-tests/src/main/resources/suites/UnversionedTests.xml
+++ b/automation-tests/src/main/resources/suites/UnversionedTests.xml
@@ -24,6 +24,12 @@
         </classes>
     </test>
 
+    <test name="Change Browser Test">
+        <classes>
+            <class name="com.automation.common.ui.app.tests.ChangeBrowserTest"/>
+        </classes>
+    </test>
+
     <test name="Data Provider Test">
         <parameter name="Data Provider Test" value="data/ui/LinksTestData.xml"/>
         <classes>
@@ -171,14 +177,6 @@
         <parameter name="allure-results" value="/home/user/allure-results-run1,/home/user/allure-results-run3"/>
         <classes>
             <class name="com.automation.common.ui.app.tests.CreateAllureReportTest"/>
-        </classes>
-    </test>
-    -->
-
-    <!--
-    <test name="Change Browser Test">
-        <classes>
-            <class name="com.automation.common.ui.app.tests.ChangeBrowserTest"/>
         </classes>
     </test>
     -->

--- a/taf/src/main/java/com/taf/automation/ui/support/testng/TestNGBaseWithoutListeners.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/testng/TestNGBaseWithoutListeners.java
@@ -183,6 +183,7 @@ public class TestNGBaseWithoutListeners {
     public void closeDriver() {
         time = (System.currentTimeMillis() - time) / 1000;
         if (context() != null && context().getDriver() != null) {
+            Utils.restoreBrowser(); // If browser was changed, ensure it is closed
             logInfo("-CLOSING CONTEXT: " + context().getDriver().toString());
             context().getDriver().quit();
         }


### PR DESCRIPTION
If using the "change browser" functionality, then it is possible that not all browsers will be closed.  This will always occur on failure.  However, it could happen in a pass situation in which the "changed browser" completes the test.  To fix this issue all that is necessary is to restore the browser before closing the browsers.

I re-factored the ChangeBrowserTest to be able to test this.  The test now uses the same browser but this does not affect the test as when you "change browsers" it is just launching another browser.  I have added it to the test suite as now no additional setup is required.

Also, added annotations for behaviors in a couple tests in which it was missing, every test has a behavior grouping now for reporting.
