### PR TITLE
Take screenshot on configuration error

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/TestNgRunnerTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/TestNgRunnerTest.java
@@ -1,0 +1,139 @@
+package com.automation.common.ui.app.tests;
+
+import com.taf.automation.ui.support.Helper;
+import com.taf.automation.ui.support.csv.ColumnMapper;
+import com.taf.automation.ui.support.testng.TestNGBase;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+import ru.yandex.qatools.allure.annotations.Features;
+import ru.yandex.qatools.allure.annotations.Severity;
+import ru.yandex.qatools.allure.annotations.Stories;
+import ru.yandex.qatools.allure.model.SeverityLevel;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class TestNgRunnerTest extends TestNGBase {
+    private TestScenario scenarioUnderTest;
+
+    private enum TestScenario implements ColumnMapper {
+        NO_FAILURE("NO_FAILURE", "https://www.google.ca/"),
+        STANDARD_FAILURE("STANDARD_FAILURE", "https://yandex.com/"),
+        BEFORE_CLASS_FAILURE("BEFORE_CLASS_FAILURE", "https://www.baidu.com/"),
+        BEFORE_TEST_FAILURE("BEFORE_TEST_FAILURE", "https://www.bing.com/"),
+        AFTER_TEST_FAILURE("AFTER_TEST_FAILURE", "https://ca.search.yahoo.com/"),
+        AFTER_CLASS_FAILURE("AFTER_CLASS_FAILURE", "https://duckduckgo.com/"),
+        ;
+        private final String columnName;
+        private final String url;
+
+        TestScenario(String columnName, String url) {
+            this.columnName = columnName;
+            this.url = url;
+        }
+
+        @Override
+        public String getColumnName() {
+            return columnName;
+        }
+
+        @Override
+        public ColumnMapper[] getValues() {
+            return values();
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+    }
+
+    private TestScenario getScenarioUnderTest(String scenario) {
+        if (scenarioUnderTest == null) {
+            scenarioUnderTest = (TestScenario) TestScenario.NO_FAILURE.toEnum(scenario);
+        }
+
+        return scenarioUnderTest;
+    }
+
+    @Features("Framework")
+    @Stories("Validate various scenarios of the test runner (TestNG)")
+    @Severity(SeverityLevel.TRIVIAL)
+    @Parameters({"scenario"})
+    @BeforeClass
+    private void runBeforeClass(String scenario) {
+        Helper.log("Running BeforeClass", true);
+
+        if (TestScenario.BEFORE_CLASS_FAILURE == getScenarioUnderTest(scenario)) {
+            getContext().getDriver().get(TestScenario.BEFORE_CLASS_FAILURE.getUrl());
+            assertThat("Failure in before class attaches screenshot & html", false);
+        }
+
+        Helper.log("Completed BeforeClass", true);
+    }
+
+    @Features("Framework")
+    @Stories("Validate various scenarios of the test runner (TestNG)")
+    @Severity(SeverityLevel.BLOCKER)
+    @Parameters({"scenario"})
+    @BeforeTest
+    private void runBeforeTest(String scenario) {
+        Helper.log("Running BeforeTest", true);
+
+        if (TestScenario.BEFORE_TEST_FAILURE == getScenarioUnderTest(scenario)) {
+            getContext().getDriver().get(TestScenario.BEFORE_TEST_FAILURE.getUrl());
+            assertThat("Failure in before test attaches screenshot & html", false);
+        }
+
+        Helper.log("Completed BeforeTest", true);
+    }
+
+    @Features("Framework")
+    @Stories("Validate various scenarios of the test runner (TestNG)")
+    @Severity(SeverityLevel.NORMAL)
+    @Parameters({"scenario"})
+    @Test
+    public void performTest(String scenario) {
+        getContext().getDriver().get(TestScenario.NO_FAILURE.getUrl());
+        if (TestScenario.STANDARD_FAILURE == getScenarioUnderTest(scenario)) {
+            getContext().getDriver().get(TestScenario.STANDARD_FAILURE.getUrl());
+            assertThat("Regular Failure in test attaches screenshot & html", false);
+        }
+    }
+
+    @Features("Framework")
+    @Stories("Validate various scenarios of the test runner (TestNG)")
+    @Severity(SeverityLevel.NORMAL)
+    @Parameters({"scenario"})
+    @AfterTest
+    private void runAfterTest(String scenario) {
+        Helper.log("Running AfterTest", true);
+
+        if (TestScenario.AFTER_TEST_FAILURE == getScenarioUnderTest(scenario)) {
+            getContext().getDriver().get(TestScenario.AFTER_TEST_FAILURE.getUrl());
+            assertThat("Failure in after test attaches screenshot & html", false);
+        }
+
+        Helper.log("Completed AfterTest", true);
+    }
+
+    @Features("Framework")
+    @Stories("Validate various scenarios of the test runner (TestNG)")
+    @Severity(SeverityLevel.MINOR)
+    @Parameters({"scenario"})
+    @AfterClass
+    private void runAfterClass(String scenario) {
+        Helper.log("Running AfterClass", true);
+
+        if (TestScenario.AFTER_CLASS_FAILURE == getScenarioUnderTest(scenario)) {
+            getContext().getDriver().get(TestScenario.AFTER_CLASS_FAILURE.getUrl());
+            assertThat("Failure in after class attaches screenshot & html", false);
+        }
+
+        Helper.log("Completed AfterClass", true);
+    }
+
+}

--- a/automation-tests/src/main/resources/suites/UnversionedTests.xml
+++ b/automation-tests/src/main/resources/suites/UnversionedTests.xml
@@ -168,6 +168,54 @@
         </classes>
     </test>
 
+    <test name="Missing Parameter Failure (before) Test">
+        <classes>
+            <class name="com.automation.common.ui.app.tests.TestNgRunnerTest"/>
+        </classes>
+    </test>
+
+    <test name="Missing Parameter Failure (at) Test">
+        <parameter name="data-set" value="data/ui/TNHC_TestData.xml"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.AllureFunctionalityTest"/>
+        </classes>
+    </test>
+
+    <test name="Standard Failure Test">
+        <parameter name="scenario" value="STANDARD_FAILURE"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.TestNgRunnerTest"/>
+        </classes>
+    </test>
+
+    <test name="Before Class Failure Test">
+        <parameter name="scenario" value="BEFORE_CLASS_FAILURE"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.TestNgRunnerTest"/>
+        </classes>
+    </test>
+
+    <test name="Before Test Failure Test">
+        <parameter name="scenario" value="BEFORE_TEST_FAILURE"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.TestNgRunnerTest"/>
+        </classes>
+    </test>
+
+    <test name="After Class Failure Test">
+        <parameter name="scenario" value="AFTER_TEST_FAILURE"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.TestNgRunnerTest"/>
+        </classes>
+    </test>
+
+    <test name="After Test Failure Test">
+        <parameter name="scenario" value="AFTER_CLASS_FAILURE"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.TestNgRunnerTest"/>
+        </classes>
+    </test>
+
     <!--
     <test name="Open Report Test">
         <parameter name="allure-report" value="/target/allure-report"/>

--- a/taf/src/main/java/com/taf/automation/ui/support/testng/AllureTestNGListener.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/testng/AllureTestNGListener.java
@@ -71,6 +71,13 @@ public class AllureTestNGListener extends AllureTestListener {
         lifecycle.fire(new TestCaseFinishedEvent());
     }
 
+    @Override
+    public void onConfigurationFailure(ITestResult iTestResult) {
+        TestNGBase.takeScreenshot("Configuration Failure Screenshot");
+        TestNGBase.takeHTML("Configuration Failure HTML Source");
+        super.onConfigurationFailure(iTestResult);
+    }
+
     private void fireTestCaseCancel(ITestResult iTestResult) {
         Throwable skipMessage = iTestResult.getThrowable();
         if (skipMessage == null) {

--- a/taf/src/main/java/com/taf/automation/ui/support/testng/TestParameterValidator.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/testng/TestParameterValidator.java
@@ -9,19 +9,19 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
 public class TestParameterValidator implements IInvokedMethodListener {
+    private static final String MSG = "Parameter %s for method %s in class %s was not found in test suite file!";
 
+    @SuppressWarnings("java:S112")
     @Override
     public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
         Method testMethod = method.getTestMethod().getConstructorOrMethod().getMethod();
         Annotation paramAnnotation = testMethod.getAnnotation(Parameters.class);
-        if (paramAnnotation != null) {
+        if (paramAnnotation != null && testResult.getTestContext() != null) {
             String[] params = ((Parameters) paramAnnotation).value();
             for (String param : params) {
                 String value = testResult.getTestContext().getCurrentXmlTest().getParameter(param);
                 if (value == null) {
-                    String msg = "Parameter " + param + " for method " + testMethod.getName() +
-                            " in class " + testMethod.getDeclaringClass().getName() +
-                            " was not found in test suite file!";
+                    String msg = String.format(MSG, param, testMethod.getName(), testMethod.getDeclaringClass().getName());
                     throw new RuntimeException(msg);
                 }
             }
@@ -30,7 +30,7 @@ public class TestParameterValidator implements IInvokedMethodListener {
 
     @Override
     public void afterInvocation(IInvokedMethod method, ITestResult testResult) {
-
+        //
     }
 
 }


### PR DESCRIPTION
If a failure occurs in method with annotation other than @Test, then no screenshot/html was taken as TestNG considered this to be a configuration failure and not a test failure.  I have updated the listener to take a screenshot/html on configuration failure to resolve this issue. 

As part of my testing, I found that testResult.getTestContext() is null on before test/class.  This causes a null pointer exception but it does not affect taking screenshots/html.  However, I fixed the null pointer exception anyway to keep the logs clean.