### PR TITLE
Configuration method will be shown in the report only on its failure in any other situation it is not listed

### DIFF
--- a/taf/src/main/java/com/taf/automation/ui/support/testng/AllureTestNGListener.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/testng/AllureTestNGListener.java
@@ -78,6 +78,12 @@ public class AllureTestNGListener extends AllureTestListener {
         super.onConfigurationFailure(iTestResult);
     }
 
+    @Override
+    public void onConfigurationSkip(ITestResult iTestResult) {
+        // Configuration method will be shown in the report only on its failure in any other situation it is not listed
+        // Note:  If this is not the behavior desire and you want the default Allure behavior then remove this method.
+    }
+
     private void fireTestCaseCancel(ITestResult iTestResult) {
         Throwable skipMessage = iTestResult.getThrowable();
         if (skipMessage == null) {


### PR DESCRIPTION
The existing behavior does not show successful configuration methods in the Allure report.  It makes sense to not show skipped configuration methods as well in the Allure report to make it cleaner and more consistent.

**Note**:  The failed configuration methods will still be displayed in the Allure report.