### PR TITLE
Change the behavior of handling unexpected alerts to ignore

### DIFF
--- a/taf/src/main/java/com/taf/automation/ui/support/WebDriverTypeEnum.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/WebDriverTypeEnum.java
@@ -199,7 +199,7 @@ public enum WebDriverTypeEnum {
         FirefoxOptions firefoxOptions = new FirefoxOptions();
         firefoxOptions.merge(mergeCapabilities);
         firefoxOptions.setProfile(profile);
-        firefoxOptions.setUnhandledPromptBehaviour(UnexpectedAlertBehaviour.DISMISS);
+        firefoxOptions.setUnhandledPromptBehaviour(UnexpectedAlertBehaviour.IGNORE);
         firefoxOptions.setAcceptInsecureCerts(true);
         firefoxOptions.setLogLevel(FirefoxDriverLogLevel.WARN);
         firefoxOptions.addArguments("--log fatal");
@@ -234,7 +234,7 @@ public enum WebDriverTypeEnum {
         }
 
         chromeOptions.merge(mergeCapabilities);
-        chromeOptions.setUnhandledPromptBehaviour(UnexpectedAlertBehaviour.DISMISS);
+        chromeOptions.setUnhandledPromptBehaviour(UnexpectedAlertBehaviour.IGNORE);
         return chromeOptions;
     }
 


### PR DESCRIPTION
Dismiss has the side effect of suppressing any unexpected alerts which can make debugging difficult as you will not be aware that an alert was displayed.  Sometimes the alert has important information about the failure.

I have changed the behavior to the original behavior of Selenium which was to ignore unexpected alerts.  This will cause an exception to be thrown on the next action.  The framework will handle clearing the alert and attaching it to the report along with the screenshot & html.

**Note**:  This will affect any test that was not handling alerts and using this Selenium behavior instead.  Additionally any test that an unexpected alert appears will fail even if the alert does not affect the application functionality or test.