### PR TITLE
Implement rules for shifting Canadian Holidays

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/DateActionsTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/DateActionsTest.java
@@ -319,4 +319,78 @@ public class DateActionsTest {
         assertThat("Independence Day - Only Business Days Before - 1 Day Before", actual, equalTo(july2));
     }
 
+    @Features("DateActions")
+    @Stories("Canada - Result Date Is New Years Day Shifted to Monday when it lands on Saturday")
+    @Severity(SeverityLevel.NORMAL)
+    @Test
+    public void performResultDateIsNewYearsShiftedToMondayFromSaturdayTest() {
+        DateActions dateActions = new DateActions();
+        // New Years Day in this case is January 3 because January 1 is a Saturday
+        Date jan3 = DateActions.parseDateStrictly("01/03/2000", DATE_FORMAT);
+
+        Date dec31 = DateActions.parseDateStrictly("12/31/1999", DATE_FORMAT);
+        Date jan4 = DateActions.parseDateStrictly("01/04/2000", DATE_FORMAT);
+
+        Date actual = dateActions.nextBusinessDay(jan3, 0);
+        assertThat("New Years Day - Next Business Day - No Days Added", actual, equalTo(jan4));
+
+        actual = dateActions.previousBusinessDay(jan3, 0);
+        assertThat("New Years Day - Previous Business Day - No Days Added", actual, equalTo(dec31));
+
+        actual = dateActions.nextBusinessDay(dec31, 1);
+        assertThat("New Years Day - Next Business Day - 1 Day After", actual, equalTo(jan4));
+
+        actual = dateActions.previousBusinessDay(jan4, -1);
+        assertThat("New Years Day - Previous Business Day - 1 Day Before", actual, equalTo(dec31));
+
+        actual = dateActions.onlyBusinessDaysAfter(jan3, 0);
+        assertThat("New Years Day - Only Business Days After - No Days Added", actual, equalTo(jan4));
+
+        actual = dateActions.onlyBusinessDaysBefore(jan3, 0);
+        assertThat("New Years Day - Only Business Days Before - No Days Added", actual, equalTo(dec31));
+
+        actual = dateActions.onlyBusinessDaysAfter(dec31, 1);
+        assertThat("New Years Day - Only Business Days After - 1 Day After", actual, equalTo(jan4));
+
+        actual = dateActions.onlyBusinessDaysBefore(jan4, -1);
+        assertThat("New Years Day - Only Business Days Before - 1 Day Before", actual, equalTo(dec31));
+    }
+
+    @Features("DateActions")
+    @Stories("Canada - Result Date Is New Years Day Shifted to Monday when it lands on Sunday")
+    @Severity(SeverityLevel.NORMAL)
+    @Test
+    public void performResultDateIsNewYearsShiftedToMondayFromSundayTest() {
+        DateActions dateActions = new DateActions();
+        // New Years Day in this case is January 2 because January 1 is a Sunday
+        Date jan2 = DateActions.parseDateStrictly("01/02/2017", DATE_FORMAT);
+
+        Date dec30 = DateActions.parseDateStrictly("12/30/2016", DATE_FORMAT);
+        Date jan3 = DateActions.parseDateStrictly("01/03/2017", DATE_FORMAT);
+
+        Date actual = dateActions.nextBusinessDay(jan2, 0);
+        assertThat("New Years Day - Next Business Day - No Days Added", actual, equalTo(jan3));
+
+        actual = dateActions.previousBusinessDay(jan2, 0);
+        assertThat("New Years Day - Previous Business Day - No Days Added", actual, equalTo(dec30));
+
+        actual = dateActions.nextBusinessDay(dec30, 1);
+        assertThat("New Years Day - Next Business Day - 1 Day After", actual, equalTo(jan3));
+
+        actual = dateActions.previousBusinessDay(jan3, -1);
+        assertThat("New Years Day - Previous Business Day - 1 Day Before", actual, equalTo(dec30));
+
+        actual = dateActions.onlyBusinessDaysAfter(jan2, 0);
+        assertThat("New Years Day - Only Business Days After - No Days Added", actual, equalTo(jan3));
+
+        actual = dateActions.onlyBusinessDaysBefore(jan2, 0);
+        assertThat("New Years Day - Only Business Days Before - No Days Added", actual, equalTo(dec30));
+
+        actual = dateActions.onlyBusinessDaysAfter(dec30, 1);
+        assertThat("New Years Day - Only Business Days After - 1 Day After", actual, equalTo(jan3));
+
+        actual = dateActions.onlyBusinessDaysBefore(jan3, -1);
+        assertThat("New Years Day - Only Business Days Before - 1 Day Before", actual, equalTo(dec30));
+    }
+
 }


### PR DESCRIPTION
I looked up all the Canadian Holidays in the past on this [site](https://www.timeanddate.com/holidays/canada) for the possible problem holidays.  The following is the data of interest for all the problem holidays:
**New Years**
- 2017 Sunday moved to Monday 
- 2000 Saturday moved to Monday

**Saint Jean Baptiste Day**
- 2000 Saturday - it did not move the observed day
- 2001 Sunday - moved to Monday

**Canada Day**
- 2000 Saturday - it did not move the observed day
- 2001 Sunday - moved to Monday

**Remembrance Day**
- 2000 Saturday - it did not move the observed day
- 2001 Sunday - moved to Monday

**Christmas Day**
- 2004 - Saturday  - it did not move the observed day
- 2005 - Sunday - moved to Monday

**Boxing Day**
- 2004 - Sunday - it did not move the observed day
- 2015 - Saturday - it did not move the observed day
- 2016 - Monday - moved to Tuesday by Christmas (this seems to be an anomaly) 

**Based on the above there are 3 scenarios to consider:**
1. New Years Day lands on a Saturday - In this case, holiday is shifted to Monday
1. Any other problem holiday lands on a Sunday - In this case, holiday is shifted to Monday
1. Boxing Day - It is not really clear what should happen.  However, it is probably safe to **not** shift.

This should resolve https://github.com/dn0000001/test-automation/issues/237 except for Boxing Day as the data is still inconclusive.
