### PR TITLE
Upgrade Allure 2 library to latest (2.13.5)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <jexcelapi.version>2.6.12</jexcelapi.version>
         <commons.csv.version>1.6</commons.csv.version>
         <fillo.version>1.18</fillo.version>
-        <io.qameta.allure.version>2.10.0</io.qameta.allure.version>
+        <io.qameta.allure.version>2.13.5</io.qameta.allure.version>
         <zip4j.version>1.3.2</zip4j.version>
         <commons.io.version>2.6</commons.io.version>
         <jaxb.api.version>2.3.1</jaxb.api.version>


### PR DESCRIPTION
**Note**:  I investigated upgrading the Allure 1 library at the same time.  However, I found that the later versions (1.5.0) contain a fix for duplicate tests.  This fix considers tests to be duplicate and removes them based on package & class name.  This is problematic for the framework because we can have tests with the package & class name which Allure 1 will remove the results as a duplicates.  For example, only the **Allure Functionality Failure Test** can be found in the report due to this behavior, the **Allure Functionality Test** is missing.
```
    <test name="Allure Functionality Test">
        <parameter name="data-set" value="data/ui/TNHC_TestData.xml"/>
        <parameter name="status" value="true"/>
        <classes>
            <class name="com.automation.common.ui.app.tests.AllureFunctionalityTest"/>
        </classes>
    </test>

    <test name="Allure Functionality Failure Test">
        <parameter name="data-set" value="data/ui/TNHC_TestData.xml"/>
        <parameter name="status" value="0"/>
        <classes>
            <class name="com.automation.common.ui.app.tests.AllureFunctionalityTest"/>
        </classes>
    </test>
```