### PR TITLE
Wrap expected condition failures

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/components/RadioButtonGroup.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/components/RadioButtonGroup.java
@@ -106,7 +106,7 @@ public class RadioButtonGroup<T extends PageComponent> extends PageComponent {
     }
 
     private List<WebElement> getOptions() {
-        return Utils.getWebDriverWait().until(ExpectedConditions.numberOfElementsToBeMoreThan(getStaticLocator(), 0));
+        return Utils.until(ExpectedConditions.numberOfElementsToBeMoreThan(getStaticLocator(), 0));
     }
 
     private boolean isMatchedOption(String displayedText, String matchToData) {

--- a/automation-tests/src/main/java/com/automation/common/ui/app/components/SelectEnhancedAJAX.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/components/SelectEnhancedAJAX.java
@@ -109,7 +109,7 @@ public class SelectEnhancedAJAX extends SelectEnhanced {
         WebElement element = (ajax) ? getDriver().findElement(getStaticLocator()) : null;
         super.setValue();
         if (ajax) {
-            Utils.getWebDriverWait().until(ExpectedConditions.stalenessOf(element));
+            Utils.until(ExpectedConditions.stalenessOf(element));
         }
     }
 

--- a/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/AddRemoveElementsPage.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/AddRemoveElementsPage.java
@@ -1,12 +1,12 @@
 package com.automation.common.ui.app.pageObjects;
 
-import com.taf.automation.ui.support.util.ExpectedConditionsUtil;
-import com.taf.automation.ui.support.util.Helper;
 import com.taf.automation.ui.support.PageObjectV2;
 import com.taf.automation.ui.support.TestContext;
-import com.taf.automation.ui.support.util.Utils;
 import com.taf.automation.ui.support.conditional.Criteria;
 import com.taf.automation.ui.support.conditional.CriteriaMaker;
+import com.taf.automation.ui.support.util.ExpectedConditionsUtil;
+import com.taf.automation.ui.support.util.Helper;
+import com.taf.automation.ui.support.util.Utils;
 import com.thoughtworks.xstream.annotations.XStreamOmitField;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -46,7 +46,7 @@ public class AddRemoveElementsPage extends PageObjectV2 {
     @Step("Click Delete Button")
     public void clickDeleteButton() {
         WebElement element = click(deleteButton);
-        Utils.getWebDriverWait().until(ExpectedConditions.invisibilityOf(element));
+        Utils.until(ExpectedConditions.invisibilityOf(element));
     }
 
     @Step("Wait For Add Element Using Lambda Expression")

--- a/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/HerokuappDataTablesPage.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/HerokuappDataTablesPage.java
@@ -1,9 +1,9 @@
 package com.automation.common.ui.app.pageObjects;
 
 import com.taf.automation.ui.support.GenericTable;
-import com.taf.automation.ui.support.util.JsUtils;
 import com.taf.automation.ui.support.Rand;
 import com.taf.automation.ui.support.TestContext;
+import com.taf.automation.ui.support.util.JsUtils;
 import com.taf.automation.ui.support.util.Utils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -75,7 +75,7 @@ public class HerokuappDataTablesPage extends GenericTable<HerokuappRow> {
         // This is just for testing purposes.  Normally, you would just use getTableRows().get(index) as we already
         // have all the rows if this type of method was really necessary.
         //
-        List<WebElement> rows = Utils.getWebDriverWait().until(ExpectedConditions.numberOfElementsToBeMoreThan(TABLE2_ROWS, index));
+        List<WebElement> rows = Utils.until(ExpectedConditions.numberOfElementsToBeMoreThan(TABLE2_ROWS, index));
         String randomIdValue = Rand.letters(10) + index;
         JsUtils.addAttributeId(rows.get(index), randomIdValue);
 

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/AssertsTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/AssertsTest.java
@@ -6,11 +6,11 @@ import com.automation.common.ui.app.components.UnitTestComponent;
 import com.automation.common.ui.app.components.UnitTestWebElement;
 import com.automation.common.ui.app.pageObjects.FakeComponentsPage;
 import com.taf.automation.ui.support.AssertAggregator;
+import com.taf.automation.ui.support.testng.TestNGBase;
 import com.taf.automation.ui.support.util.AssertsUtil;
+import com.taf.automation.ui.support.util.ExpectedConditionsUtil;
 import com.taf.automation.ui.support.util.Helper;
 import com.taf.automation.ui.support.util.Utils;
-import com.taf.automation.ui.support.testng.TestNGBase;
-import com.taf.automation.ui.support.util.ExpectedConditionsUtil;
 import net.jodah.failsafe.Failsafe;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableInt;
@@ -568,7 +568,7 @@ public class AssertsTest extends TestNGBase {
     public void assertComponentCannotBeSetTest() {
         String valueToUse = "Does not matter";
         getContext().getDriver().get("https://duckduckgo.com/");
-        WebElement element = Utils.getWebDriverWait().until(ExpectedConditionsUtil.ready(By.name("q")));
+        WebElement element = Utils.until(ExpectedConditionsUtil.ready(By.name("q")));
         UnitTestComponent component = new UnitTestComponent(element)
                 .withEnabled(true)
                 .withDisplayed(true);

--- a/taf/src/main/java/com/taf/automation/ui/support/ColumnPositionsExtractor.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/ColumnPositionsExtractor.java
@@ -60,7 +60,7 @@ public interface ColumnPositionsExtractor {
         Map<String, String> columnPositions = new HashMap<>();
 
         int position = 1;
-        List<WebElement> headers = Utils.getWebDriverWait().until(ExpectedConditions.numberOfElementsToBeMoreThan(getColumnHeadersLocator(), 0));
+        List<WebElement> headers = Utils.until(ExpectedConditions.numberOfElementsToBeMoreThan(getColumnHeadersLocator(), 0));
         for (WebElement header : headers) {
             String key = extractHeaderAsKey(header, position);
             if (key != null) {

--- a/taf/src/main/java/com/taf/automation/ui/support/GenericTable.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/GenericTable.java
@@ -61,7 +61,7 @@ public abstract class GenericTable<T extends GenericRow> extends PageObjectV2 {
 
         String randomBaseValue = getRandomBaseValue();
         Map<String, String> substitutions = getSubstitutions();
-        List<WebElement> all = Utils.getWebDriverWait().until(ExpectedConditions.numberOfElementsToBeMoreThan(getAllRowsLocator(), 0));
+        List<WebElement> all = Utils.until(ExpectedConditions.numberOfElementsToBeMoreThan(getAllRowsLocator(), 0));
         for (int i = 0; i < all.size(); i++) {
             // If necessary, we will make the row unique
             String randomIdValue = randomBaseValue + i;

--- a/taf/src/main/java/com/taf/automation/ui/support/PageObjectV2.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/PageObjectV2.java
@@ -510,7 +510,7 @@ public class PageObjectV2 extends PageObjectModel {
         assertThat("Click Component", component, notNullValue());
         assertThat("Click Component's Locator", component.getLocator(), notNullValue());
         return Failsafe.with(Utils.getClickRetryPolicy()).get(() -> {
-            WebElement element = Utils.getWebDriverWait().until(ExpectedConditionsUtil.ready(component));
+            WebElement element = Utils.until(ExpectedConditionsUtil.ready(component));
             component.click();
             return element;
         });

--- a/taf/src/main/java/com/taf/automation/ui/support/testng/TestNGBaseWithoutListeners.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/testng/TestNGBaseWithoutListeners.java
@@ -2,9 +2,9 @@ package com.taf.automation.ui.support.testng;
 
 import com.taf.automation.api.html.HtmlUtils;
 import com.taf.automation.ui.support.DomainObject;
-import com.taf.automation.ui.support.util.ExpectedConditionsUtil;
 import com.taf.automation.ui.support.TestContext;
 import com.taf.automation.ui.support.TestProperties;
+import com.taf.automation.ui.support.util.ExpectedConditionsUtil;
 import com.taf.automation.ui.support.util.Utils;
 import datainstiller.data.DataPersistence;
 import io.appium.java_client.AppiumDriver;
@@ -46,9 +46,7 @@ public class TestNGBaseWithoutListeners {
     public static void takeScreenshot(String title) {
         if (context() != null && context().getDriver() != null) {
             try {
-                Utils.getWebDriverWait()
-                        .until(ExpectedConditionsUtil.takeScreenshot(title))
-                        .forEach(Attachment::build);
+                Utils.until(ExpectedConditionsUtil.takeScreenshot(title)).forEach(Attachment::build);
             } catch (Exception ex) {
                 String shortMessage = "Could not take screenshot for " + title;
                 StringWriter sw = new StringWriter();

--- a/taf/src/main/java/com/taf/automation/ui/support/util/JsUtils.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/util/JsUtils.java
@@ -430,9 +430,7 @@ public class JsUtils {
      * @return window handle of 1st new window that appears
      */
     public static String openNewWindow(String url) {
-        return Utils.getWebDriverWait().until(ExpectedConditionsUtil.handle(
-                () -> execute(getWebDriver(), OPEN_NEW_WINDOW, url)
-        ));
+        return Utils.until(ExpectedConditionsUtil.handle(() -> execute(getWebDriver(), OPEN_NEW_WINDOW, url)));
     }
 
     /**


### PR DESCRIPTION
There are 3 reasons for this work:
1. In the Allure report, when expected conditions fail they are displayed as broken.  I would like them to be shown as failed instead.  The way Allure is currently determines if broken vs failed is based on whether it is an assertion failure.  Any assertion failure makes the test failed and any other exception causes it to be displayed as broken.
1. This makes using expected conditions shorter and more convenient.
1. Selenium 4 - Alpha 6 has re-implemented the method for this and it has changed the behavior to be different than Selenium 3.  (From looking at the code, it seems that it was implemented incorrectly.)  As a result, of this it is throwing intermittently InterruptedException and on timeout the expected condition failure reason is not being used always.  By wrapping the method, we can get the same (correct) behavior as in Selenium 3 which will make upgrading easier.