### PR TITLE
Fix performance of cannot set assertion & Fix component setting value if disabled

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/components/CardExpirationDateFields.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/components/CardExpirationDateFields.java
@@ -3,8 +3,15 @@ package com.automation.common.ui.app.components;
 import com.taf.automation.ui.support.ComponentPO;
 import com.taf.automation.ui.support.TestContext;
 import com.taf.automation.ui.support.util.Utils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.openqa.selenium.support.FindBy;
 import ru.yandex.qatools.allure.annotations.Step;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
 
 /**
  * A page object that acts as a component
@@ -56,6 +63,135 @@ public class CardExpirationDateFields extends ComponentPO {
 
     public void updateMonthTestData(String value) {
         month.initializeData(value, null, null);
+    }
+
+    @Step("Validate Year - SelectEnhanced.setValue")
+    public void validateYearSelectEnhancedSetValue() {
+        final String YEAR_VISUAL_TEXT_VALUE = "2021";
+        final String YEAR_HTML_VALUE = "2021";
+        final String YEAR_INDEX_VALUE = "2";
+        final String YEAR_REGEX_VISUAL_TEXT_VALUE = ".*21";
+        final String YEAR_REGEX_HTML_VALUE = ".*21";
+
+        final String VISIBLE_TEXT = "VISIBLE_TEXT >>> ";
+        final String VALUE_HTML = "VALUE_HTML >>> ";
+        final String INDEX = "INDEX >>> ";
+        final String VISIBLE_TEXT_REGEX = "VISIBLE_TEXT_REGEX >>> ";
+        final String VALUE_HTML_REGEX = "VALUE_HTML_REGEX >>> ";
+        final String RANDOM_INDEX = "RANDOM_INDEX >>> ";
+        final String RANDOM_INDEX_VALUES = "RANDOM_INDEX_VALUES >>> ";
+        final String RANDOM_INDEX_RANGE = "RANDOM_INDEX_RANGE >>> ";
+
+        //
+        // Basic common ways to select the value
+        //
+
+        String reason = "Year - Visible Text (default)";
+        String value = YEAR_VISUAL_TEXT_VALUE;
+        String expectedValue = YEAR_VISUAL_TEXT_VALUE;
+        validateSetValue(reason, value, expectedValue);
+        resetYear();
+
+        reason = "Year - Visible Text (Explicit)";
+        value = VISIBLE_TEXT + YEAR_VISUAL_TEXT_VALUE;
+        validateSetValue(reason, value, expectedValue);
+        resetYear();
+
+        reason = "Year - Value";
+        value = VALUE_HTML + YEAR_HTML_VALUE;
+        validateSetValue(reason, value, expectedValue);
+        resetYear();
+
+        reason = "Year - Index";
+        value = INDEX + YEAR_INDEX_VALUE;
+        validateSetValue(reason, value, expectedValue);
+        resetYear();
+
+        reason = "Year - RegEx Visible Text";
+        value = VISIBLE_TEXT_REGEX + YEAR_REGEX_VISUAL_TEXT_VALUE;
+        validateSetValue(reason, value, expectedValue);
+        resetYear();
+
+        reason = "Year - RegEx Value";
+        value = VALUE_HTML_REGEX + YEAR_REGEX_HTML_VALUE;
+        validateSetValue(reason, value, expectedValue);
+        resetYear();
+
+        //
+        // Random ways to select the value
+        //
+
+        reason = "Year - Random Index";
+        value = RANDOM_INDEX + "7";
+        int actualYear = NumberUtils.toInt(setYear(value));
+        assertThat(reason, actualYear, greaterThanOrEqualTo(2026));
+        resetYear();
+
+        reason = "Year - Random Index Values";
+        value = RANDOM_INDEX_VALUES + "7,8";
+        assertThat(
+                reason,
+                setYear(value),
+                anyOf(equalTo("2026"), equalTo("2027"))
+        );
+        resetYear();
+
+        reason = "Year - Random Index Range";
+        value = RANDOM_INDEX_RANGE + "7:12";
+        actualYear = NumberUtils.toInt(setYear(value));
+        assertThat(reason, actualYear, greaterThanOrEqualTo(2026));
+        assertThat(reason, actualYear, lessThan(2031));
+        resetYear();
+
+        //
+        // Value already selected tests
+        //
+        resetYear();
+        resetYear();
+
+        // Set the value for the tests that follow
+        setYear(YEAR_VISUAL_TEXT_VALUE);
+
+        reason = "Year - Already Selected - Visible Text (default)";
+        value = YEAR_VISUAL_TEXT_VALUE;
+        validateSetValue(reason, value, expectedValue);
+
+        reason = "Year - Already Selected - Visible Text (Explicit)";
+        value = VISIBLE_TEXT + YEAR_VISUAL_TEXT_VALUE;
+        validateSetValue(reason, value, expectedValue);
+
+        reason = "Year - Already Selected - Value";
+        value = VALUE_HTML + YEAR_HTML_VALUE;
+        validateSetValue(reason, value, expectedValue);
+
+        reason = "Year - Already Selected - Index";
+        value = INDEX + YEAR_INDEX_VALUE;
+        validateSetValue(reason, value, expectedValue);
+
+        reason = "Year - Already Selected - RegEx Visible Text";
+        value = VISIBLE_TEXT_REGEX + YEAR_REGEX_VISUAL_TEXT_VALUE;
+        validateSetValue(reason, value, expectedValue);
+
+        reason = "Year - Already Selected - RegEx Value";
+        value = VALUE_HTML_REGEX + YEAR_HTML_VALUE;
+        validateSetValue(reason, value, expectedValue);
+    }
+
+    @Step("Validate SetValue:  {0}")
+    private void validateSetValue(String reason, String value, String expectedValue) {
+        assertThat(reason, setYear(value), equalTo(expectedValue));
+    }
+
+    @Step("Set Year:  {0}")
+    private String setYear(String value) {
+        setElementValueV2(value, year);
+        return year.getValue();
+    }
+
+    @Step("Reset Year")
+    private void resetYear() {
+        String value = "2025";
+        assertThat("Year - 2025", setYear(value), equalTo(value));
     }
 
 }

--- a/automation-tests/src/main/java/com/automation/common/ui/app/components/CheckBoxAJAX.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/components/CheckBoxAJAX.java
@@ -12,6 +12,8 @@ import ui.auto.core.pagecomponent.PageComponent;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 /**
  * Check Box component that works with AJAX
  */
@@ -81,12 +83,14 @@ public class CheckBoxAJAX extends PageComponent {
 
     public void check() {
         if (!isSelected()) {
+            assertThat("CheckBoxAJAX was disabled", isEnabled());
             Utils.clickAndWaitForStale(getCheckBox());
         }
     }
 
     public void uncheck() {
         if (isSelected()) {
+            assertThat("CheckBoxAJAX was disabled", isEnabled());
             Utils.clickAndWaitForStale(getCheckBox());
         }
     }

--- a/automation-tests/src/main/java/com/automation/common/ui/app/components/CheckBoxLabel.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/components/CheckBoxLabel.java
@@ -6,6 +6,8 @@ import org.testng.Assert;
 import ui.auto.core.data.DataTypes;
 import ui.auto.core.pagecomponent.PageComponent;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 /**
  * Check Box component that bypasses issues where WebDriver does not allow normal interaction with the check box as
  * it is disabled instead clicking the label node toggles the state<BR>
@@ -40,12 +42,14 @@ public class CheckBoxLabel extends PageComponent {
 
     public void check() {
         if (!isSelected()) {
+            assertThat("CheckBoxLabel was disabled", isEnabled());
             label.click();
         }
     }
 
     public void uncheck() {
         if (isSelected()) {
+            assertThat("CheckBoxLabel was disabled", isEnabled());
             label.click();
         }
     }

--- a/automation-tests/src/main/java/com/automation/common/ui/app/components/CreditCardFields.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/components/CreditCardFields.java
@@ -2,16 +2,28 @@ package com.automation.common.ui.app.components;
 
 import com.taf.automation.ui.support.ComponentPO;
 import com.taf.automation.ui.support.TestContext;
+import com.taf.automation.ui.support.util.Helper;
+import com.taf.automation.ui.support.util.JsUtils;
 import com.taf.automation.ui.support.util.Utils;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import org.openqa.selenium.support.FindBy;
 import ru.yandex.qatools.allure.annotations.Step;
+import ui.auto.core.pagecomponent.PageComponent;
+
+import static com.taf.automation.ui.support.util.AssertsUtil.componentCannotBeSet;
+import static com.taf.automation.ui.support.util.AssertsUtil.componentCannotBeSetFast;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 
 /**
  * A page object that acts as a component and contains a sub-page object component
  */
 @SuppressWarnings("squid:MaximumInheritanceDepth")
 public class CreditCardFields extends ComponentPO {
+    private static final String DISCOVER = "Discover";
+
     @FindBy(css = "select[name$='type']")
     private SelectEnhanced creditCardType;
 
@@ -28,6 +40,9 @@ public class CreditCardFields extends ComponentPO {
 
     @FindBy(css = "[name$='cc_uname']")
     private TextBox cardUserName;
+
+    @FindBy(css = "select[name$='type']")
+    private SelectEnhancedAJAX creditCardTypeFake;
 
     public CreditCardFields() {
         super();
@@ -92,6 +107,228 @@ public class CreditCardFields extends ComponentPO {
     @Override
     public void validate() {
         // No actions required to validate
+    }
+
+    @Step("Validate Credit Card Type - SelectEnhanced.setValue")
+    public void validateCreditCardTypeSelectEnhancedSetValue() {
+        final String CREDIT_CARD_TYPE_VISUAL_TEXT_VALUE = "Visa (Preferred)";
+        final String CREDIT_CARD_TYPE_HTML_VALUE = "9";
+        final String CREDIT_CARD_TYPE_INDEX_VALUE = "1";
+        final String CREDIT_CARD_TYPE_REGEX_VISUAL_TEXT_VALUE = "Visa \\(Preferred\\)";
+        final String CREDIT_CARD_TYPE_INDEX_0_OPTION = "(Select Card Type)";
+        final String CREDIT_CARD_TYPE_INDEX_4_OPTION = DISCOVER;
+        final String CREDIT_CARD_TYPE_INDEX_5_OPTION = "Diners Club";
+
+        final String VISIBLE_TEXT = "VISIBLE_TEXT >>> ";
+        final String VALUE_HTML = "VALUE_HTML >>> ";
+        final String INDEX = "INDEX >>> ";
+        final String VISIBLE_TEXT_REGEX = "VISIBLE_TEXT_REGEX >>> ";
+        final String VALUE_HTML_REGEX = "VALUE_HTML_REGEX >>> ";
+        final String RANDOM_INDEX = "RANDOM_INDEX >>> ";
+        final String RANDOM_INDEX_VALUES = "RANDOM_INDEX_VALUES >>> ";
+        final String RANDOM_INDEX_RANGE = "RANDOM_INDEX_RANGE >>> ";
+
+        //
+        // Basic common ways to select the value
+        //
+
+        String reason = "Credit Card Type - Visible Text (default)";
+        String value = CREDIT_CARD_TYPE_VISUAL_TEXT_VALUE;
+        String expectedValue = CREDIT_CARD_TYPE_VISUAL_TEXT_VALUE;
+        validateSetValue(reason, value, expectedValue);
+        resetCreditCardType();
+
+        reason = "Credit Card Type - Visible Text (Explicit)";
+        value = VISIBLE_TEXT + CREDIT_CARD_TYPE_VISUAL_TEXT_VALUE;
+        validateSetValue(reason, value, expectedValue);
+        resetCreditCardType();
+
+        reason = "Credit Card Type - Value";
+        value = VALUE_HTML + CREDIT_CARD_TYPE_HTML_VALUE;
+        validateSetValue(reason, value, expectedValue);
+        resetCreditCardType();
+
+        reason = "Credit Card Type - Index";
+        value = INDEX + CREDIT_CARD_TYPE_INDEX_VALUE;
+        validateSetValue(reason, value, expectedValue);
+        resetCreditCardType();
+
+        reason = "Credit Card Type - RegEx Visible Text";
+        value = VISIBLE_TEXT_REGEX + CREDIT_CARD_TYPE_REGEX_VISUAL_TEXT_VALUE;
+        validateSetValue(reason, value, expectedValue);
+        resetCreditCardType();
+
+        reason = "Credit Card Type - RegEx Value";
+        value = VALUE_HTML_REGEX + CREDIT_CARD_TYPE_HTML_VALUE;
+        validateSetValue(reason, value, expectedValue);
+        resetCreditCardType();
+
+        //
+        // Random ways to select the value
+        //
+
+        reason = "Credit Card Type - Random Index";
+        value = RANDOM_INDEX + "1";
+        assertThat(reason, setCreditCardType(value), not(equalTo(CREDIT_CARD_TYPE_INDEX_0_OPTION)));
+        resetCreditCardType();
+
+        reason = "Credit Card Type - Random Index Values";
+        value = RANDOM_INDEX_VALUES + "1,4";
+        assertThat(
+                reason,
+                setCreditCardType(value),
+                anyOf(equalTo(CREDIT_CARD_TYPE_VISUAL_TEXT_VALUE), equalTo(CREDIT_CARD_TYPE_INDEX_4_OPTION))
+        );
+        resetCreditCardType();
+
+        reason = "Credit Card Type - Random Index Range";
+        value = RANDOM_INDEX_RANGE + "4:5";
+        assertThat(
+                reason,
+                setCreditCardType(value),
+                anyOf(equalTo(CREDIT_CARD_TYPE_INDEX_4_OPTION), equalTo(CREDIT_CARD_TYPE_INDEX_5_OPTION))
+        );
+        resetCreditCardType();
+
+        //
+        // Value already selected tests
+        //
+        resetCreditCardType();
+        resetCreditCardType();
+
+        // Set the value for the tests that follow
+        setCreditCardType(CREDIT_CARD_TYPE_VISUAL_TEXT_VALUE);
+
+        reason = "Credit Card Type - Already Selected - Visible Text (default)";
+        value = CREDIT_CARD_TYPE_VISUAL_TEXT_VALUE;
+        validateSetValue(reason, value, expectedValue);
+
+        reason = "Credit Card Type - Already Selected - Visible Text (Explicit)";
+        value = VISIBLE_TEXT + CREDIT_CARD_TYPE_VISUAL_TEXT_VALUE;
+        validateSetValue(reason, value, expectedValue);
+
+        reason = "Credit Card Type - Already Selected - Value";
+        value = VALUE_HTML + CREDIT_CARD_TYPE_HTML_VALUE;
+        validateSetValue(reason, value, expectedValue);
+
+        reason = "Credit Card Type - Already Selected - Index";
+        value = INDEX + CREDIT_CARD_TYPE_INDEX_VALUE;
+        validateSetValue(reason, value, expectedValue);
+
+        reason = "Credit Card Type - Already Selected - RegEx Visible Text";
+        value = VISIBLE_TEXT_REGEX + CREDIT_CARD_TYPE_REGEX_VISUAL_TEXT_VALUE;
+        validateSetValue(reason, value, expectedValue);
+
+        reason = "Credit Card Type - Already Selected - RegEx Value";
+        value = VALUE_HTML_REGEX + CREDIT_CARD_TYPE_HTML_VALUE;
+        validateSetValue(reason, value, expectedValue);
+    }
+
+    @Step("Validate SetValue:  {0}")
+    private void validateSetValue(String reason, String value, String expectedValue) {
+        assertThat(reason, setCreditCardType(value), equalTo(expectedValue));
+    }
+
+    @Step("Set Credit Card Type:  {0}")
+    private String setCreditCardType(String value) {
+        setElementValueV2(value, creditCardType);
+        return creditCardType.getValue();
+    }
+
+    @Step("Reset Credit Card Type")
+    private void resetCreditCardType() {
+        String value = "Master Card";
+        assertThat("Credit Card Type - Master Card", setCreditCardType(value), equalTo(value));
+    }
+
+    @Step("Validate Negative SelectEnhanced.setValue")
+    public void validateNegativeSelectEnhancedSetValue() {
+        final String WALMART_CARD = "Walmart Card";
+        final String VISIBLE_TEXT = "VISIBLE_TEXT >>> ";
+        final String VALUE_HTML = "VALUE_HTML >>> ";
+        final String INDEX = "INDEX >>> ";
+        final String VISIBLE_TEXT_REGEX = "VISIBLE_TEXT_REGEX >>> ";
+        final String VALUE_HTML_REGEX = "VALUE_HTML_REGEX >>> ";
+
+        String reason = "Visible Text does not exist";
+        String value = WALMART_CARD;
+        validateCannotSetInvalidOption(value, reason);
+
+        reason = "Visible Text (Explicit) does not exist";
+        value = VISIBLE_TEXT + WALMART_CARD;
+        validateCannotSetInvalidOption(value, reason);
+
+        reason = "Value does not exist";
+        value = VALUE_HTML + WALMART_CARD;
+        validateCannotSetInvalidOption(value, reason);
+
+        reason = "Index greater than available options";
+        value = INDEX + "1000";
+        validateCannotSetInvalidOption(value, reason);
+
+        reason = "Index less than 0";
+        value = INDEX + "-5";
+        validateCannotSetInvalidOption(value, reason);
+
+        reason = "Index not a number";
+        value = INDEX + "testValue";
+        validateCannotSetInvalidOption(value, reason);
+
+        reason = "RegEx Visible Text does not match";
+        value = VISIBLE_TEXT_REGEX + WALMART_CARD;
+        validateCannotSetInvalidOption(value, reason);
+
+        reason = "RegEx Value does not match";
+        value = VALUE_HTML_REGEX + WALMART_CARD;
+        validateCannotSetInvalidOption(value, reason);
+    }
+
+    @SuppressWarnings("java:S112")
+    @Step("Validate Cannot Set Invalid Option:  {0}")
+    private void validateCannotSetInvalidOption(String value, String reason) {
+        try {
+            setElementValueV2(value, creditCardType);
+            throw new RuntimeException("Assertion did not fail:  " + reason);
+        } catch (AssertionError ae) {
+            Helper.log("setElementValueV2 failed as expected - " + reason, true);
+        }
+    }
+
+    public void validateYearSelectEnhancedSetValue() {
+        getCardExpirationDate().validateYearSelectEnhancedSetValue();
+    }
+
+    @Step("Disable Fields And Validate Cannot Set")
+    public void disableFieldsAndValidateCannotSet() {
+        disableFieldAndValidateCreditCardNumber();
+        disableFieldAndValidateCreditCardType();
+        disableFieldAndValidateCreditCardTypeFake();
+    }
+
+    private void disableField(PageComponent component) {
+        JsUtils.addAttribute(component.getCoreElement(), "disabled", "");
+    }
+
+    private void configureCreditCardType(PageComponent temp) {
+        ((SelectEnhanced) temp).useNegativeRetryPolicy();
+    }
+
+    @Step("Disable And Validate:  Credit Card Number")
+    private void disableFieldAndValidateCreditCardNumber() {
+        disableField(creditCardNumber);
+        assertThat("Credit Card Number", creditCardNumber, componentCannotBeSetFast("1235"));
+    }
+
+    @Step("Disable And Validate:  Credit Card Type")
+    private void disableFieldAndValidateCreditCardType() {
+        disableField(creditCardType);
+        assertThat("Credit Card Type", creditCardType, componentCannotBeSet(DISCOVER, this::configureCreditCardType));
+    }
+
+    @Step("Disable And Validate:  Credit Card Type (Fake)")
+    private void disableFieldAndValidateCreditCardTypeFake() {
+        disableField(creditCardTypeFake);
+        assertThat("Credit Card Type (Fake)", creditCardTypeFake, componentCannotBeSet(DISCOVER, this::configureCreditCardType));
     }
 
 }

--- a/automation-tests/src/main/java/com/automation/common/ui/app/components/SelectEnhancedAJAX.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/components/SelectEnhancedAJAX.java
@@ -2,6 +2,7 @@ package com.automation.common.ui.app.components;
 
 import com.taf.automation.ui.support.util.LocatorUtils;
 import com.taf.automation.ui.support.util.Utils;
+import com.thoughtworks.xstream.annotations.XStreamOmitField;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.openqa.selenium.By;
@@ -9,6 +10,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.Select;
+import org.openqa.selenium.support.ui.WebDriverWait;
 import ui.auto.core.data.DataTypes;
 
 import java.util.HashMap;
@@ -46,6 +48,9 @@ public class SelectEnhancedAJAX extends SelectEnhanced {
     private WebDriver driver;
     private Map<String, String> substitutions;
     private By staticLocator;
+
+    @XStreamOmitField
+    private WebDriverWait wait;
 
     public SelectEnhancedAJAX() {
         super();
@@ -96,6 +101,22 @@ public class SelectEnhancedAJAX extends SelectEnhanced {
         this.staticLocator = null;
     }
 
+    private WebDriverWait getWebDriverWait() {
+        if (wait == null) {
+            return Utils.getWebDriverWait();
+        }
+
+        return wait;
+    }
+
+    public void useNegativeWebDriverWait() {
+        setWebDriverWait(Utils.getNegativeWebDriverWait());
+    }
+
+    public void setWebDriverWait(WebDriverWait wait) {
+        this.wait = wait;
+    }
+
     @Override
     public String getValue() {
         initSelect();
@@ -109,7 +130,7 @@ public class SelectEnhancedAJAX extends SelectEnhanced {
         WebElement element = (ajax) ? getDriver().findElement(getStaticLocator()) : null;
         super.setValue();
         if (ajax) {
-            Utils.until(ExpectedConditions.stalenessOf(element));
+            Utils.until(ExpectedConditions.stalenessOf(element), getWebDriverWait(), getRetryPolicy());
         }
     }
 

--- a/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/RoboFormLoginPage.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/RoboFormLoginPage.java
@@ -1,0 +1,88 @@
+package com.automation.common.ui.app.pageObjects;
+
+import com.automation.common.ui.app.components.CheckBoxAJAX;
+import com.automation.common.ui.app.components.CheckBoxLabel;
+import com.automation.common.ui.app.components.TextBox;
+import com.taf.automation.ui.support.PageObjectV2;
+import com.taf.automation.ui.support.TestContext;
+import com.taf.automation.ui.support.util.JsUtils;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import ru.yandex.qatools.allure.annotations.Step;
+import ui.auto.core.pagecomponent.PageComponent;
+
+import static com.taf.automation.ui.support.util.AssertsUtil.componentCannotBeSetFast;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class RoboFormLoginPage extends PageObjectV2 {
+    private static final String VALUE_TO_BE_SET = "false";
+
+    @FindBy(id = "username")
+    private TextBox emailOrUserId;
+
+    @FindBy(id = "password")
+    private TextBox password;
+
+    @FindBy(id = "safe_device")
+    private CheckBoxAJAX rememberAJAX;
+
+    @FindBy(xpath = "//*[@id='safe_device']/..")
+    private CheckBoxLabel rememberLabel;
+
+    public RoboFormLoginPage() {
+        super();
+    }
+
+    public RoboFormLoginPage(TestContext context) {
+        super(context);
+    }
+
+    @Step("Disable Fields And Validate Cannot Set")
+    public void disableFieldsAndValidateCannotSet() {
+        disableFieldAndValidateEmailOrUserId();
+        disableFieldAndValidatePassword();
+        disableFieldAndValidateRememberLabel();
+        disableFieldAndValidateRememberAJAX();
+    }
+
+    private void disableField(PageComponent component) {
+        disableField(component.getCoreElement());
+    }
+
+    private void disableField(WebElement element) {
+        JsUtils.addAttribute(element, "disabled", "");
+    }
+
+    private void makeCheckBoxVisible(By locator) {
+        WebElement element = getDriver().findElement(locator);
+        JsUtils.execute(getDriver(), "arguments[0].style.opacity = 1;", element);
+    }
+
+    @Step("Disable And Validate:  Email Or User Id")
+    private void disableFieldAndValidateEmailOrUserId() {
+        disableField(emailOrUserId);
+        assertThat("Email Or User Id", emailOrUserId, componentCannotBeSetFast("1235"));
+    }
+
+    @Step("Disable And Validate:  Password")
+    private void disableFieldAndValidatePassword() {
+        disableField(password);
+        assertThat("Password", password, componentCannotBeSetFast("67890"));
+    }
+
+    @Step("Disable And Validate:  Remember (Label)")
+    private void disableFieldAndValidateRememberLabel() {
+        disableField(rememberLabel.getInput());
+        assertThat("Remember (Label)", rememberLabel, componentCannotBeSetFast(VALUE_TO_BE_SET));
+    }
+
+    @Step("Disable And Validate:  Remember (AJAX)")
+    private void disableFieldAndValidateRememberAJAX() {
+        // On this page the element is considered hidden, it is necessary to make it displayed for the test
+        makeCheckBoxVisible(rememberAJAX.getLocator());
+        disableField(rememberAJAX);
+        assertThat("Remember (AJAX)", rememberAJAX, componentCannotBeSetFast(VALUE_TO_BE_SET));
+    }
+
+}

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/AssertsTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/AssertsTest.java
@@ -1,10 +1,12 @@
 package com.automation.common.ui.app.tests;
 
 import com.automation.common.ui.app.components.CardExpirationDateFields;
+import com.automation.common.ui.app.components.CreditCardFields;
 import com.automation.common.ui.app.components.TextBox;
 import com.automation.common.ui.app.components.UnitTestComponent;
 import com.automation.common.ui.app.components.UnitTestWebElement;
 import com.automation.common.ui.app.pageObjects.FakeComponentsPage;
+import com.automation.common.ui.app.pageObjects.RoboFormLoginPage;
 import com.taf.automation.ui.support.AssertAggregator;
 import com.taf.automation.ui.support.testng.TestNGBase;
 import com.taf.automation.ui.support.util.AssertsUtil;
@@ -580,6 +582,50 @@ public class AssertsTest extends TestNGBase {
         component.withEnabled(false).withDisplayed(false);
         assertThat("UnitTestComponent (not ready)", component, AssertsUtil.componentCannotBeSet(valueToUse));
         Helper.log("UnitTestComponent (not ready) - complete:  " + new Date(), true);
+    }
+
+    @Features("AssertsUtil")
+    @Stories("Validate Component Cannot Be Set Assertion")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void assertComponentCannotBeSetFastTest() {
+        getContext().getDriver().get("https://www.roboform.com/filling-test-all-fields");
+        CreditCardFields creditCardFields = new CreditCardFields(getContext());
+        creditCardFields.disableFieldsAndValidateCannotSet();
+
+        getContext().getDriver().get("https://online.roboform.com/login");
+        RoboFormLoginPage roboFormLoginPage = new RoboFormLoginPage(getContext());
+        roboFormLoginPage.disableFieldsAndValidateCannotSet();
+    }
+
+    @Features("SelectEnhanced")
+    @Stories("SelectEnhanced.setValue method functions properly")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void validateCreditCardTypeSelectEnhancedSetValue() {
+        getContext().getDriver().get("https://www.roboform.com/filling-test-all-fields");
+        CreditCardFields creditCardFields = new CreditCardFields(getContext());
+        creditCardFields.validateCreditCardTypeSelectEnhancedSetValue();
+    }
+
+    @Features("SelectEnhanced")
+    @Stories("SelectEnhanced.setValue method functions properly")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void validateYearSelectEnhancedSetValue() {
+        getContext().getDriver().get("https://www.roboform.com/filling-test-all-fields");
+        CreditCardFields creditCardFields = new CreditCardFields(getContext());
+        creditCardFields.validateYearSelectEnhancedSetValue();
+    }
+
+    @Features("SelectEnhanced")
+    @Stories("SelectEnhanced.setValue method functions properly")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void validateNegativeSelectEnhancedSetValue() {
+        getContext().getDriver().get("https://www.roboform.com/filling-test-all-fields");
+        CreditCardFields creditCardFields = new CreditCardFields(getContext());
+        creditCardFields.validateNegativeSelectEnhancedSetValue();
     }
 
     @Features("AssertsUtil")

--- a/automation-tests/src/main/resources/suites/FrameworkSmokeTestSuite.xml
+++ b/automation-tests/src/main/resources/suites/FrameworkSmokeTestSuite.xml
@@ -2,6 +2,52 @@
 
 <suite name="Framework Smoke Test Suite" verbose="1" parallel="tests" thread-count="5" data-provider-thread-count="5">
 
+    <test name="Asserts Test - Part 1 (SelectEnhanced)">
+        <parameter name="data-set" value="data/ui/TNHC_TestData.xml"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.AssertsTest">
+                <methods>
+                    <include name="validateCreditCardTypeSelectEnhancedSetValue"/>
+                </methods>
+            </class>
+        </classes>
+    </test>
+
+    <test name="Asserts Test - Part 2 (SelectEnhanced)">
+        <parameter name="data-set" value="data/ui/TNHC_TestData.xml"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.AssertsTest">
+                <methods>
+                    <include name="validateYearSelectEnhancedSetValue"/>
+                </methods>
+            </class>
+        </classes>
+    </test>
+
+    <test name="Asserts Test - Part 3 (SelectEnhanced)">
+        <parameter name="data-set" value="data/ui/TNHC_TestData.xml"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.AssertsTest">
+                <methods>
+                    <include name="validateNegativeSelectEnhancedSetValue"/>
+                </methods>
+            </class>
+        </classes>
+    </test>
+
+    <test name="Asserts Test - Part 4">
+        <parameter name="data-set" value="data/ui/TNHC_TestData.xml"/>
+        <classes>
+            <class name="com.automation.common.ui.app.tests.AssertsTest">
+                <methods>
+                    <exclude name="validateCreditCardTypeSelectEnhancedSetValue"/>
+                    <exclude name="validateYearSelectEnhancedSetValue"/>
+                    <exclude name="validateNegativeSelectEnhancedSetValue"/>
+                </methods>
+            </class>
+        </classes>
+    </test>
+
     <test name="Herokuapp Data Table Test">
         <parameter name="url" value="https://the-internet.herokuapp.com/tables"/>
         <classes>
@@ -78,13 +124,6 @@
         <parameter name="url" value="https://the-internet.herokuapp.com/add_remove_elements/"/>
         <classes>
             <class name="com.automation.common.ui.app.tests.ExpectedConditionsMatcherTest"/>
-        </classes>
-    </test>
-
-    <test name="Asserts Test">
-        <parameter name="data-set" value="data/ui/TNHC_TestData.xml"/>
-        <classes>
-            <class name="com.automation.common.ui.app.tests.AssertsTest"/>
         </classes>
     </test>
 


### PR DESCRIPTION
The performance of the original AssertsUtil.componentCannotBeSet is inherently slow because it uses setElementValueV2 which uses Utils.getWriteValueRetryPolicy.  This means that it always takes element timeout.  However, we are expecting not be able to set the value as such it would be better if the negative timeout could be used.  I have implemented another AssertsUtil.componentCannotBeSet which will complete faster by using attempts for non-AJAX components.  For AJAX components, it is necessary to allow for the use of a custom retry policy to make it faster.

As I re-factored the AJAX components, I found that a number of components would allow you to set them even when they were disabled.  

The **CheckBoxAJAX** & **CheckBoxLabel** would attempt to toggle the state even if disabled.  However, the validation would not be successful.  So, as long as you were using setElementValueV2 this bug was not really of concern.  It is only a problem in the case where the checkbox was disabled and you only used setValue as it would not fail but the state would not change.  In this case, we just need to add an assertion to ensure it is enabled before attempting to change the state.  This behavior change should not have any negative impact but it will catch attempts to change the state on disabled check boxes which is desired from a testing point of view.

The **SelectEnhanced** & **SelectEnhancedAJAX** is much more complicated situation.  It was using the Selenium Select class behind the scenes which allows you to select disabled options even though the user cannot do this in the application.  There are 2 disabled validations that need to occur.  The first case is where the entire drop down is disabled.  (This was easy to validation without a lot of code change.)  The second case is where the specific option to be selected is disabled.  This was difficult for the basic Selenium options to select the option:  Visible Text, Value & Index.  It was necessary to look at the Selenium code for these options and act in a similar way for Value & Index the Selenium code is straight forward but Visible Text was some what convoluted.  I implemented:
- Index:  Matches on the attribute "index" of the element
- Value:  Matches on the attribute "value" of the element
- Visible Text:  Matches on the visible text exactly or after normalizing the spaces.

