### PR TITLE
Fix component setting value if disabled for radio groups

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/components/RadioButtonGroup.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/components/RadioButtonGroup.java
@@ -134,10 +134,17 @@ public class RadioButtonGroup<T extends PageComponent> extends PageComponent {
         for (WebElement option : options) {
             T component = getInstanceOfT(option);
             if (isMatchedOption(component.getText(), theData)) {
+                if (component.isSelected()) {
+                    return;
+                }
+
+                assertThat("Radio Option was disabled", component.isEnabled());
                 component.setValue();
                 return;
             }
         }
+
+        assertThat("Could not find radio option:  " + theData, false);
     }
 
     @SuppressWarnings("squid:S2259")

--- a/automation-tests/src/main/java/com/automation/common/ui/app/components/RadioOption.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/components/RadioOption.java
@@ -35,6 +35,11 @@ public class RadioOption extends PageComponent {
     }
 
     @Override
+    public boolean isEnabled() {
+        return input.isEnabled();
+    }
+
+    @Override
     public void click() {
         setValue();
     }


### PR DESCRIPTION
Previously, it was possible to attempt to set a radio group option even if it was disabled.  Also, the setValue method would not indicate any error if the option could not be found.

**Note**:  Since, setElementValueV2 is the recommended way to set a component, this issue would be mitigated for the most part.  The only case which a failure would not be caught was if the option was disabled but it could still be selected, in this case the validation would be successful.