### PR TITLE
Store most URLs in the sample-environment.xml instead of using parame…

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/Navigation.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/Navigation.java
@@ -4,6 +4,10 @@ import com.taf.automation.ui.support.TestContext;
 import com.taf.automation.ui.support.TestProperties;
 import ru.yandex.qatools.allure.annotations.Step;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
+
 public class Navigation {
     private TestContext context;
     private TestProperties props = TestProperties.getInstance();
@@ -13,18 +17,51 @@ public class Navigation {
         this.context = context;
     }
 
-    @Step("Go to Home Page")
-    public void toHome(boolean cleanCookies) {
+    @Step("Go to {0} Page")
+    private void toURL(String page, String url, boolean cleanCookies) {
         if (cleanCookies) {
             context.getDriver().manage().deleteAllCookies();
         }
 
-        context.getDriver().get(homeUrl);
+        assertThat("URL", url, not(isEmptyOrNullString()));
+        context.getDriver().get(url);
+    }
+
+    public void toHome(boolean cleanCookies) {
+        toURL("Home", homeUrl, cleanCookies);
     }
 
     @Step("Go to Relative Path {0}")
     public void toURL(String path) {
         context.getDriver().get(homeUrl + path);
+    }
+
+    public void toHerokuappTables(boolean cleanCookies) {
+        toURL("Herokuapp - Tables", props.getCustom("herokuapp-tables-url", null), cleanCookies);
+    }
+
+    public void toHerokuappElements(boolean cleanCookies) {
+        toURL("Herokuapp - Elements", props.getCustom("herokuapp-elements-url", null), cleanCookies);
+    }
+
+    public void toDuckDuckGo(boolean cleanCookies) {
+        toURL("Duck Duck Go", props.getCustom("duckduckgo-url", null), cleanCookies);
+    }
+
+    public void toPrimefacesDashboard(boolean cleanCookies) {
+        toURL("Primefaces Dashboard", props.getCustom("primefaces-dashboard-url", null), cleanCookies);
+    }
+
+    public void toRoboFormFill(boolean cleanCookies) {
+        toURL("RoboForm - Fill", props.getCustom("roboform-fill-url", null), cleanCookies);
+    }
+
+    public void toRoboFormLogin(boolean cleanCookies) {
+        toURL("RoboForm - Login", props.getCustom("roboform-login-url", null), cleanCookies);
+    }
+
+    public void toTrueNorthHockey(boolean cleanCookies) {
+        toURL("True North Hockey", props.getCustom("true-north-hockey-url", null), cleanCookies);
     }
 
 }

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/AssertsTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/AssertsTest.java
@@ -6,6 +6,7 @@ import com.automation.common.ui.app.components.TextBox;
 import com.automation.common.ui.app.components.UnitTestComponent;
 import com.automation.common.ui.app.components.UnitTestWebElement;
 import com.automation.common.ui.app.pageObjects.FakeComponentsPage;
+import com.automation.common.ui.app.pageObjects.Navigation;
 import com.automation.common.ui.app.pageObjects.RoboFormLoginPage;
 import com.taf.automation.ui.support.AssertAggregator;
 import com.taf.automation.ui.support.testng.TestNGBase;
@@ -17,7 +18,6 @@ import net.jodah.failsafe.Failsafe;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.testng.annotations.Test;
@@ -467,10 +467,8 @@ public class AssertsTest extends TestNGBase {
     @Severity(SeverityLevel.CRITICAL)
     @Test(enabled = RUN)
     public void assertIsDisplayedWithByExistTest() {
-        WebDriver driver = getContext().getDriver();
-        driver.get("http://www.truenorthhockey.com/");
-
-        assertThat(By.id("headersearch"), AssertsUtil.isElementDisplayed(driver));
+        new Navigation(getContext()).toTrueNorthHockey(Utils.isCleanCookiesSupported());
+        assertThat(By.id("headersearch"), AssertsUtil.isElementDisplayed(getContext().getDriver()));
     }
 
     @Features("AssertsUtil")
@@ -496,10 +494,8 @@ public class AssertsTest extends TestNGBase {
     @Severity(SeverityLevel.CRITICAL)
     @Test(enabled = RUN)
     public void assertIsEnabledWithByExistTest() {
-        WebDriver driver = getContext().getDriver();
-        driver.get("http://www.truenorthhockey.com/");
-
-        assertThat(By.id("headersearch"), AssertsUtil.isElementEnabled(driver));
+        new Navigation(getContext()).toTrueNorthHockey(Utils.isCleanCookiesSupported());
+        assertThat(By.id("headersearch"), AssertsUtil.isElementEnabled(getContext().getDriver()));
     }
 
     @Features("AssertsUtil")
@@ -568,8 +564,8 @@ public class AssertsTest extends TestNGBase {
     @Severity(SeverityLevel.CRITICAL)
     @Test
     public void assertComponentCannotBeSetTest() {
+        new Navigation(getContext()).toDuckDuckGo(Utils.isCleanCookiesSupported());
         String valueToUse = "Does not matter";
-        getContext().getDriver().get("https://duckduckgo.com/");
         WebElement element = Utils.until(ExpectedConditionsUtil.ready(By.name("q")));
         UnitTestComponent component = new UnitTestComponent(element)
                 .withEnabled(true)
@@ -589,11 +585,11 @@ public class AssertsTest extends TestNGBase {
     @Severity(SeverityLevel.CRITICAL)
     @Test
     public void assertComponentCannotBeSetFastTest() {
-        getContext().getDriver().get("https://www.roboform.com/filling-test-all-fields");
+        new Navigation(getContext()).toRoboFormFill(Utils.isCleanCookiesSupported());
         CreditCardFields creditCardFields = new CreditCardFields(getContext());
         creditCardFields.disableFieldsAndValidateCannotSet();
 
-        getContext().getDriver().get("https://online.roboform.com/login");
+        new Navigation(getContext()).toRoboFormLogin(Utils.isCleanCookiesSupported());
         RoboFormLoginPage roboFormLoginPage = new RoboFormLoginPage(getContext());
         roboFormLoginPage.disableFieldsAndValidateCannotSet();
     }
@@ -603,7 +599,7 @@ public class AssertsTest extends TestNGBase {
     @Severity(SeverityLevel.CRITICAL)
     @Test
     public void validateCreditCardTypeSelectEnhancedSetValue() {
-        getContext().getDriver().get("https://www.roboform.com/filling-test-all-fields");
+        new Navigation(getContext()).toRoboFormFill(Utils.isCleanCookiesSupported());
         CreditCardFields creditCardFields = new CreditCardFields(getContext());
         creditCardFields.validateCreditCardTypeSelectEnhancedSetValue();
     }
@@ -613,7 +609,7 @@ public class AssertsTest extends TestNGBase {
     @Severity(SeverityLevel.CRITICAL)
     @Test
     public void validateYearSelectEnhancedSetValue() {
-        getContext().getDriver().get("https://www.roboform.com/filling-test-all-fields");
+        new Navigation(getContext()).toRoboFormFill(Utils.isCleanCookiesSupported());
         CreditCardFields creditCardFields = new CreditCardFields(getContext());
         creditCardFields.validateYearSelectEnhancedSetValue();
     }
@@ -623,7 +619,7 @@ public class AssertsTest extends TestNGBase {
     @Severity(SeverityLevel.CRITICAL)
     @Test
     public void validateNegativeSelectEnhancedSetValue() {
-        getContext().getDriver().get("https://www.roboform.com/filling-test-all-fields");
+        new Navigation(getContext()).toRoboFormFill(Utils.isCleanCookiesSupported());
         CreditCardFields creditCardFields = new CreditCardFields(getContext());
         creditCardFields.validateNegativeSelectEnhancedSetValue();
     }

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/ExpectedConditionsMatcherTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/ExpectedConditionsMatcherTest.java
@@ -1,9 +1,9 @@
 package com.automation.common.ui.app.tests;
 
 import com.automation.common.ui.app.pageObjects.AddRemoveElementsPage;
+import com.automation.common.ui.app.pageObjects.Navigation;
 import com.taf.automation.ui.support.testng.TestNGBase;
-import org.testng.annotations.Optional;
-import org.testng.annotations.Parameters;
+import com.taf.automation.ui.support.util.Utils;
 import org.testng.annotations.Test;
 import ru.yandex.qatools.allure.annotations.Features;
 import ru.yandex.qatools.allure.annotations.Severity;
@@ -17,10 +17,9 @@ public class ExpectedConditionsMatcherTest extends TestNGBase {
     @Features("Framework")
     @Stories("Conditional - ExpectedConditionsMatch")
     @Severity(SeverityLevel.CRITICAL)
-    @Parameters("url")
     @Test
-    public void performTest(@Optional("https://the-internet.herokuapp.com/add_remove_elements/") String url) {
-        getContext().getDriver().get(url);
+    public void performTest() {
+        new Navigation(getContext()).toHerokuappElements(Utils.isCleanCookiesSupported());
         AddRemoveElementsPage addRemoveElementsPage = new AddRemoveElementsPage();
         addRemoveElementsPage.initPage(getContext());
         addRemoveElementsPage.waitForAddElementUsingExpectedCondition();

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/HerokuappDataTableEqualsTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/HerokuappDataTableEqualsTest.java
@@ -4,11 +4,10 @@ import com.automation.common.ui.app.pageObjects.HerokuappDataTable1Page;
 import com.automation.common.ui.app.pageObjects.HerokuappDataTablesPage;
 import com.automation.common.ui.app.pageObjects.HerokuappRow;
 import com.automation.common.ui.app.pageObjects.HerokuappRowTable1;
+import com.automation.common.ui.app.pageObjects.Navigation;
 import com.taf.automation.api.JsonUtils;
-import com.taf.automation.ui.support.util.Utils;
 import com.taf.automation.ui.support.testng.TestNGBase;
-import org.testng.annotations.Optional;
-import org.testng.annotations.Parameters;
+import com.taf.automation.ui.support.util.Utils;
 import org.testng.annotations.Test;
 import ru.yandex.qatools.allure.annotations.Features;
 import ru.yandex.qatools.allure.annotations.Severity;
@@ -49,10 +48,9 @@ public class HerokuappDataTableEqualsTest extends TestNGBase {
     @Features("Framework")
     @Stories("Page Object with Dynamic Locators used to represent a row in a table")
     @Severity(SeverityLevel.CRITICAL)
-    @Parameters("url")
     @Test
-    public void verifyTable1EqualsTable2Test(@Optional("https://the-internet.herokuapp.com/tables") String url) {
-        getContext().getDriver().get(url);
+    public void verifyTable1EqualsTable2Test() {
+        new Navigation(getContext()).toHerokuappTables(Utils.isCleanCookiesSupported());
 
         List<Table> table2Rows = new ArrayList<>();
         HerokuappDataTablesPage table2 = new HerokuappDataTablesPage(getContext());

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/HerokuappDataTableTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/HerokuappDataTableTest.java
@@ -2,11 +2,10 @@ package com.automation.common.ui.app.tests;
 
 import com.automation.common.ui.app.pageObjects.HerokuappDataTablesPage;
 import com.automation.common.ui.app.pageObjects.HerokuappRow;
+import com.automation.common.ui.app.pageObjects.Navigation;
 import com.taf.automation.api.JsonUtils;
-import com.taf.automation.ui.support.util.Utils;
 import com.taf.automation.ui.support.testng.TestNGBase;
-import org.testng.annotations.Optional;
-import org.testng.annotations.Parameters;
+import com.taf.automation.ui.support.util.Utils;
 import org.testng.annotations.Test;
 import ru.yandex.qatools.allure.annotations.Features;
 import ru.yandex.qatools.allure.annotations.Severity;
@@ -47,11 +46,11 @@ public class HerokuappDataTableTest extends TestNGBase {
     @Features("Framework")
     @Stories("Page Object with Dynamic Locators used to represent a row in a table")
     @Severity(SeverityLevel.CRITICAL)
-    @Parameters("url")
     @Test
-    public void getAllDataTest(@Optional("https://the-internet.herokuapp.com/tables") String url) {
+    public void getAllDataTest() {
+        new Navigation(getContext()).toHerokuappTables(Utils.isCleanCookiesSupported());
+
         List<Table2> actualRows = new ArrayList<>();
-        getContext().getDriver().get(url);
         HerokuappDataTablesPage tablesPage = new HerokuappDataTablesPage(getContext());
         List<HerokuappRow> all = tablesPage.getAllRows();
         for (HerokuappRow row : all) {

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/LambdaExpressionMatcherTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/LambdaExpressionMatcherTest.java
@@ -1,9 +1,9 @@
 package com.automation.common.ui.app.tests;
 
 import com.automation.common.ui.app.pageObjects.AddRemoveElementsPage;
+import com.automation.common.ui.app.pageObjects.Navigation;
 import com.taf.automation.ui.support.testng.TestNGBase;
-import org.testng.annotations.Optional;
-import org.testng.annotations.Parameters;
+import com.taf.automation.ui.support.util.Utils;
 import org.testng.annotations.Test;
 import ru.yandex.qatools.allure.annotations.Features;
 import ru.yandex.qatools.allure.annotations.Severity;
@@ -17,10 +17,9 @@ public class LambdaExpressionMatcherTest extends TestNGBase {
     @Features("Framework")
     @Stories("Conditional - LambdaExpressionMatch")
     @Severity(SeverityLevel.CRITICAL)
-    @Parameters("url")
     @Test
-    public void performTest(@Optional("https://the-internet.herokuapp.com/add_remove_elements/") String url) {
-        getContext().getDriver().get(url);
+    public void performTest() {
+        new Navigation(getContext()).toHerokuappElements(Utils.isCleanCookiesSupported());
         AddRemoveElementsPage addRemoveElementsPage = new AddRemoveElementsPage();
         addRemoveElementsPage.initPage(getContext());
         addRemoveElementsPage.waitForAddElementUsingLambdaExpression();

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/PrimeFacesDashboardTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/PrimeFacesDashboardTest.java
@@ -1,7 +1,9 @@
 package com.automation.common.ui.app.tests;
 
 import com.automation.common.ui.app.domainObjects.PrimeFacesDashboardDO;
+import com.automation.common.ui.app.pageObjects.Navigation;
 import com.taf.automation.ui.support.testng.TestNGBase;
+import com.taf.automation.ui.support.util.Utils;
 import org.testng.annotations.Optional;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
@@ -14,13 +16,10 @@ public class PrimeFacesDashboardTest extends TestNGBase {
     @Features("Framework")
     @Stories("Page Object with Locators (like a component)")
     @Severity(SeverityLevel.CRITICAL)
-    @Parameters({"url", "data-set"})
+    @Parameters({"data-set"})
     @Test
-    public void testPageObjectWithLocator(
-            @Optional("https://www.primefaces.org/showcase/ui/panel/dashboard.xhtml") String url,
-            @Optional("data/ui/PrimeFacesDashboard_TestData.xml") String dataSet
-    ) {
-        getContext().getDriver().get(url);
+    public void testPageObjectWithLocator(@Optional("data/ui/PrimeFacesDashboard_TestData.xml") String dataSet) {
+        new Navigation(getContext()).toPrimefacesDashboard(Utils.isCleanCookiesSupported());
         PrimeFacesDashboardDO primeFacesDashboardDO = new PrimeFacesDashboardDO(getContext()).fromResource(dataSet);
         primeFacesDashboardDO.getPrimeFacesDashboardPage().validateLocatorsNotNull();
         primeFacesDashboardDO.getPrimeFacesDashboardPage().validateFakePanelLocatorIsNull();

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/RetryTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/RetryTest.java
@@ -1,11 +1,11 @@
 package com.automation.common.ui.app.tests;
 
+import com.automation.common.ui.app.pageObjects.Navigation;
 import com.taf.automation.ui.support.TestProperties;
 import com.taf.automation.ui.support.testng.Retry;
 import com.taf.automation.ui.support.testng.TestNGBase;
+import com.taf.automation.ui.support.util.Utils;
 import org.apache.commons.lang3.mutable.MutableInt;
-import org.testng.annotations.Optional;
-import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 import ru.yandex.qatools.allure.annotations.Features;
 import ru.yandex.qatools.allure.annotations.Severity;
@@ -23,19 +23,13 @@ public class RetryTest extends TestNGBase {
     @Features("Framework")
     @Stories("Validate the retry functionality")
     @Severity(SeverityLevel.CRITICAL)
-    @Parameters("url")
     @Test
     @Retry
-    public void testThatPassesOnRetry(@Optional("https://duckduckgo.com/") String url) {
+    public void testThatPassesOnRetry() {
         assertThat("test.default.retry", TestProperties.getInstance().getTestDefaultRetry(), greaterThan(0));
-        goToUrl(url);
+        new Navigation(getContext()).toDuckDuckGo(Utils.isCleanCookiesSupported());
         performActionThatFailsIntermittently();
         performOtherActionsOfTest();
-    }
-
-    @Step("Go to URL:  {0}")
-    private void goToUrl(String url) {
-        getContext().getDriver().get(url);
     }
 
     @Step("Perform Action That Fails Intermittently")

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/RoboFormTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/RoboFormTest.java
@@ -1,7 +1,9 @@
 package com.automation.common.ui.app.tests;
 
 import com.automation.common.ui.app.domainObjects.RoboFormDO;
+import com.automation.common.ui.app.pageObjects.Navigation;
 import com.taf.automation.ui.support.testng.TestNGBase;
+import com.taf.automation.ui.support.util.Utils;
 import org.testng.annotations.Optional;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
@@ -15,13 +17,10 @@ public class RoboFormTest extends TestNGBase {
     @Features("Framework")
     @Stories("Using setElementValueV2 with ComponentPO")
     @Severity(SeverityLevel.CRITICAL)
-    @Parameters({"url", "data-set"})
+    @Parameters({"data-set"})
     @Test
-    public void testSetElementValueV2WithComponentPO(
-            @Optional("https://www.roboform.com/filling-test-all-fields") String url,
-            @Optional("data/ui/RoboForm_TestData.xml") String dataSet
-    ) {
-        getContext().getDriver().get(url);
+    public void testSetElementValueV2WithComponentPO(@Optional("data/ui/RoboForm_TestData.xml") String dataSet) {
+        new Navigation(getContext()).toRoboFormFill(Utils.isCleanCookiesSupported());
         RoboFormDO roboFormDO = new RoboFormDO(getContext()).fromResource(dataSet);
         if (roboFormDO.isUseDynamicPage()) {
             fillUsingDynamicComponentPO(roboFormDO);

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/RowMatchingTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/RowMatchingTest.java
@@ -3,7 +3,9 @@ package com.automation.common.ui.app.tests;
 import com.automation.common.ui.app.domainObjects.RowMatchingDO;
 import com.automation.common.ui.app.pageObjects.HerokuappDataTablesPage;
 import com.automation.common.ui.app.pageObjects.HerokuappRow;
+import com.automation.common.ui.app.pageObjects.Navigation;
 import com.taf.automation.ui.support.testng.TestNGBase;
+import com.taf.automation.ui.support.util.Utils;
 import org.testng.annotations.Optional;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
@@ -23,13 +25,10 @@ public class RowMatchingTest extends TestNGBase {
     @Features("Framework")
     @Stories("Matching rows in tables")
     @Severity(SeverityLevel.CRITICAL)
-    @Parameters({"url", "data-set"})
+    @Parameters({"data-set"})
     @Test
-    public void performRowMatching(
-            @Optional("https://the-internet.herokuapp.com/tables") String url,
-            @Optional("data/ui/RowMatching_TestData.xml") String dataSet
-    ) {
-        getContext().getDriver().get(url);
+    public void performRowMatching(@Optional("data/ui/RowMatching_TestData.xml") String dataSet) {
+        new Navigation(getContext()).toHerokuappTables(Utils.isCleanCookiesSupported());
         rowMatchingDO = new RowMatchingDO(getContext()).fromResource(dataSet);
         tablesPage = new HerokuappDataTablesPage(getContext());
 

--- a/automation-tests/src/main/resources/data/ui/sample-environment.xml
+++ b/automation-tests/src/main/resources/data/ui/sample-environment.xml
@@ -26,6 +26,15 @@
         <prop name="feature-x" value="true"/>
         <prop name="feature-y" value="false"/>
 
+        <!-- URLs for tests.  We can store here instead of test.properties -->
+        <prop name="herokuapp-tables-url" value="https://the-internet.herokuapp.com/tables"/>
+        <prop name="herokuapp-elements-url" value="https://the-internet.herokuapp.com/add_remove_elements/"/>
+        <prop name="duckduckgo-url" value="https://duckduckgo.com/"/>
+        <prop name="primefaces-dashboard-url" value="https://www.primefaces.org/showcase/ui/panel/dashboard.xhtml"/>
+        <prop name="roboform-fill-url" value="https://www.roboform.com/filling-test-all-fields"/>
+        <prop name="roboform-login-url" value="https://online.roboform.com/login"/>
+        <prop name="true-north-hockey-url" value="http://www.truenorthhockey.com/"/>
+
         <!-- There is bug in UserProvider class of ui_auto_core 2.5.15 that requires at least 1 user with a role -->
         <user role="user" userName="u2" password="xzRZ75G077/YqCsRSAHGMw=="/>
         <user role="super" userName="s2" password="feuGPPZDZlkVmHXJwOISwQ=="/>

--- a/automation-tests/src/main/resources/suites/FrameworkSmokeTestSuite.xml
+++ b/automation-tests/src/main/resources/suites/FrameworkSmokeTestSuite.xml
@@ -49,21 +49,18 @@
     </test>
 
     <test name="Herokuapp Data Table Test">
-        <parameter name="url" value="https://the-internet.herokuapp.com/tables"/>
         <classes>
             <class name="com.automation.common.ui.app.tests.HerokuappDataTableTest"/>
         </classes>
     </test>
 
     <test name="Herokuapp Data Table Equals Test">
-        <parameter name="url" value="https://the-internet.herokuapp.com/tables"/>
         <classes>
             <class name="com.automation.common.ui.app.tests.HerokuappDataTableEqualsTest"/>
         </classes>
     </test>
 
     <test name="Row Matching Test">
-        <parameter name="url" value="https://the-internet.herokuapp.com/tables"/>
         <parameter name="data-set" value="data/ui/RowMatching_TestData.xml"/>
         <classes>
             <class name="com.automation.common.ui.app.tests.RowMatchingTest"/>
@@ -100,7 +97,6 @@
     </test>
 
     <test name="Retry with Pass Test">
-        <parameter name="url" value="https://duckduckgo.com/"/>
         <classes>
             <class name="com.automation.common.ui.app.tests.RetryTest"/>
         </classes>
@@ -114,14 +110,12 @@
     </test>
 
     <test name="Lambda Expression Matcher Test">
-        <parameter name="url" value="https://the-internet.herokuapp.com/add_remove_elements/"/>
         <classes>
             <class name="com.automation.common.ui.app.tests.LambdaExpressionMatcherTest"/>
         </classes>
     </test>
 
     <test name="Expected Conditions Matcher Test">
-        <parameter name="url" value="https://the-internet.herokuapp.com/add_remove_elements/"/>
         <classes>
             <class name="com.automation.common.ui.app.tests.ExpectedConditionsMatcherTest"/>
         </classes>
@@ -179,7 +173,6 @@
     </test>
 
     <test name="PrimeFaces Dashboard Test">
-        <parameter name="url" value="https://www.primefaces.org/showcase/ui/panel/dashboard.xhtml"/>
         <parameter name="data-set" value="data/ui/PrimeFacesDashboard_TestData.xml"/>
         <classes>
             <class name="com.automation.common.ui.app.tests.PrimeFacesDashboardTest"/>
@@ -187,7 +180,6 @@
     </test>
 
     <test name="RoboForm Test">
-        <parameter name="url" value="https://www.roboform.com/filling-test-all-fields"/>
         <parameter name="data-set" value="data/ui/RoboForm_TestData.xml"/>
         <classes>
             <class name="com.automation.common.ui.app.tests.RoboFormTest"/>
@@ -195,7 +187,6 @@
     </test>
 
     <test name="RoboFormDynamic Test">
-        <parameter name="url" value="https://www.roboform.com/filling-test-all-fields"/>
         <parameter name="data-set" value="data/ui/RoboFormDynamic_TestData.xml"/>
         <classes>
             <class name="com.automation.common.ui.app.tests.RoboFormTest"/>


### PR DESCRIPTION
…ters on tests

This seemed like a good place to show how to use the environment config file to store URLs instead of using test.properties.

PROs:
- Less 1st time setup
- Easy to switch environments

CONs:
- Can only use known environments for build systems like Jenkins
- May make it more difficult to parameterize for build systems like Jenkins

**Note**:  You can also use a hybrid model where it uses test.properties with fallback to environment config file.