### PR TITLE
Upgrade various libraries

### DIFF
--- a/automation-tests/src/main/resources/data/ui/LinksTestData.xml
+++ b/automation-tests/src/main/resources/data/ui/LinksTestData.xml
@@ -9,5 +9,7 @@
         <string>https://yandex.com/</string>
         <string>https://duckduckgo.com/</string>
         <string>https://krebsonsecurity.com/</string>
+        <string>https://self-signed.badssl.com/</string>
+        <string>http://test.rubywatir.com/checkboxes.php</string>
     </links>
 </links-do>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <aspectj.maven.plugin.version>1.12.1</aspectj.maven.plugin.version>
         <aspectj.version>1.9.2</aspectj.version>
         <maven-assembly-plugin>2.6</maven-assembly-plugin>
+        <guava.version>25.0-jre</guava.version>
         <selenium.version>3.141.59</selenium.version>
         <appium.version>7.3.0</appium.version>
         <ui.auto.core.version>2.5.15</ui.auto.core.version>
@@ -28,21 +29,21 @@
         <hamcrest.version>1.3</hamcrest.version>
         <jetty-server.version>9.4.3.v20170317</jetty-server.version>
         <java.mail.version>1.4.1</java.mail.version>
-        <jsoup.version>1.8.3</jsoup.version>
+        <jsoup.version>1.13.1</jsoup.version>
         <jsch.version>0.1.53</jsch.version>
         <failsafe.version>2.3.4</failsafe.version>
         <springframework.version>4.2.4.RELEASE</springframework.version>
         <mysql-connector.version>5.1.38</mysql-connector.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <httpclient.version>4.5.3</httpclient.version>
+        <httpclient.version>4.5.12</httpclient.version>
         <pdfbox.version>1.8.2</pdfbox.version>
         <vtd.version>2.11</vtd.version>
         <jackson.version>2.9.8</jackson.version>
-        <apache.commons.version>3.4</apache.commons.version>
+        <apache.commons.version>3.11</apache.commons.version>
         <findbugs.version>3.0.1</findbugs.version>
         <consul.version>1.3.0</consul.version>
         <browser.mob.proxy.version>2.1.5</browser.mob.proxy.version>
-        <httpmime.version>4.5.5</httpmime.version>
+        <httpmime.version>4.5.12</httpmime.version>
         <axe.selenium.version>2.0</axe.selenium.version>
         <sql.server.version>6.4.0.jre8</sql.server.version>
         <cucumber.version>1.2.5</cucumber.version>

--- a/taf/pom.xml
+++ b/taf/pom.xml
@@ -74,6 +74,11 @@
             <version>${allure.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
             <version>${selenium.version}</version>
@@ -112,11 +117,6 @@
             <groupId>javax.mail</groupId>
             <artifactId>mail</artifactId>
             <version>${java.mail.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-            <version>${findbugs.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>

--- a/taf/src/main/java/com/taf/automation/api/html/HtmlUtils.java
+++ b/taf/src/main/java/com/taf/automation/api/html/HtmlUtils.java
@@ -1,18 +1,24 @@
 package com.taf.automation.api.html;
 
+import com.taf.automation.api.TrustAllStrategy;
 import com.taf.automation.ui.support.TestProperties;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.conn.ssl.TrustStrategy;
+import org.apache.http.ssl.SSLContexts;
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,16 +30,19 @@ import java.util.concurrent.TimeUnit;
 public class HtmlUtils {
     private Document doc;
     private int timeout;
+    private SSLSocketFactory sslSocketFactory;
 
     public HtmlUtils() {
         doc = null;
         setTimeout((int) TimeUnit.SECONDS.toMillis(TestProperties.getInstance().getElementTimeout()));
         setProxy();
+        setSslSocketFactory(getDefaultSocketFactory());
     }
 
     public HtmlUtils(String url) {
         setTimeout((int) TimeUnit.SECONDS.toMillis(TestProperties.getInstance().getElementTimeout()));
         setProxy();
+        setSslSocketFactory(getDefaultSocketFactory());
         navigate(url);
     }
 
@@ -41,10 +50,35 @@ public class HtmlUtils {
         timeout = timeoutInMilliSeconds;
     }
 
-    private Connection getConnection(String url) {
-        return Jsoup.connect(url).validateTLSCertificates(false).ignoreContentType(true).timeout(timeout);
+    public void setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
+        this.sslSocketFactory = sslSocketFactory;
     }
 
+    @SuppressWarnings("java:S112")
+    private SSLSocketFactory getDefaultSocketFactory() {
+        SSLContext sslContext;
+
+        try {
+            TrustStrategy trustStrategy;
+            if (TestProperties.getInstance().getEnvironment().isProdEnv()) {
+                trustStrategy = new TrustSelfSignedStrategy();
+            } else {
+                trustStrategy = new TrustAllStrategy();
+            }
+
+            sslContext = SSLContexts.custom().loadTrustMaterial(null, trustStrategy).build();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        return sslContext.getSocketFactory();
+    }
+
+    private Connection getConnection(String url) {
+        return Jsoup.connect(url).sslSocketFactory(sslSocketFactory).ignoreContentType(true).timeout(timeout);
+    }
+
+    @SuppressWarnings("java:S112")
     public Connection.Response navigate(String url, String userAgent) {
         try {
             Connection.Response response = getConnection(url)
@@ -59,6 +93,7 @@ public class HtmlUtils {
         }
     }
 
+    @SuppressWarnings("java:S112")
     public void navigate(String url) {
         try {
             doc = getConnection(url).get();
@@ -109,6 +144,7 @@ public class HtmlUtils {
         }
     }
 
+    @SuppressWarnings("java:S112")
     public static Map<String, String> getQueryParams(String url) {
         Map<String, String> qValues = new HashMap<>();
         URI uri;
@@ -119,7 +155,7 @@ public class HtmlUtils {
         }
 
         qValues.put("host", uri.getHost());
-        List<NameValuePair> params = URLEncodedUtils.parse(uri, Charset.forName("UTF-8"));
+        List<NameValuePair> params = URLEncodedUtils.parse(uri, StandardCharsets.UTF_8);
         for (NameValuePair param : params) {
             qValues.put(param.getName(), param.getValue());
         }
@@ -133,6 +169,7 @@ public class HtmlUtils {
      * @param url             - URL
      * @param followRedirects - true if server redirects should be followed
      */
+    @SuppressWarnings("java:S112")
     public void post(String url, boolean followRedirects) {
         try {
             doc = getConnection(url).followRedirects(followRedirects).post();

--- a/taf/src/main/java/com/taf/automation/ui/support/util/Utils.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/util/Utils.java
@@ -1426,9 +1426,9 @@ public class Utils {
      * @return The function's return value if the function returned something different
      * from null or false before the timeout expired
      */
-    public static <T> T until(Function<WebDriver, T> isTrue, WebDriverWait wait, RetryPolicy<Object> retryPolicy) {
+    public static <T> T until(ExpectedCondition<T> isTrue, WebDriverWait wait, RetryPolicy<Object> retryPolicy) {
         try {
-            return Failsafe.with(retryPolicy).get((ExecutionContext t) -> wait.until(isTrue));
+            return Failsafe.with(retryPolicy).get((ExecutionContext t) -> wait.until((Function<? super WebDriver, T>) isTrue));
         } catch (TimeoutException te) {
             Duration timeout = (Duration) ApiUtils.readField(FieldUtils.getField(FluentWait.class, "timeout", true), wait);
             Duration interval = (Duration) ApiUtils.readField(FieldUtils.getField(FluentWait.class, "interval", true), wait);
@@ -1467,7 +1467,7 @@ public class Utils {
      * @return The function's return value if the function returned something different
      * from null or false before the timeout expired
      */
-    public static <T> T until(Function<WebDriver, T> isTrue, boolean negative) {
+    public static <T> T until(ExpectedCondition<T> isTrue, boolean negative) {
         WebDriverWait wait;
         int timeout;
         if (negative) {
@@ -1496,7 +1496,7 @@ public class Utils {
      * @return The function's return value if the function returned something different
      * from null or false before the timeout expired
      */
-    public static <T> T until(Function<WebDriver, T> isTrue) {
+    public static <T> T until(ExpectedCondition<T> isTrue) {
         return until(isTrue, false);
     }
 


### PR DESCRIPTION
- Investigated upgrading to testNG 7.3.0 and encountered 'cannot infer type-variable' issue.  I made a fix to Utils.until to prevent this when upgrading in the future as there are still issues in testNG 7 that need to be resolved.
- There was also a Guava conflict with testNG 7.3.0 in my preliminary testing.  This was resolved by updating the pom.xml with a specific version of Guava.
- Updated httpclient & httpmime to same version (4.5.12)
- Upgrade commons-lang3 to latest version (3.11)
- Upgrade jsoup to latest version (1.13.1)  This required re-factoring to support self signed certificates due to library changes.