### PR TITLE
Add support to filter rows

### DIFF
--- a/taf/src/main/java/com/taf/automation/ui/support/GenericTable.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/GenericTable.java
@@ -2,6 +2,7 @@ package com.taf.automation.ui.support;
 
 import com.taf.automation.ui.support.conditional.Criteria;
 import com.taf.automation.ui.support.conditional.CriteriaMaker;
+import com.taf.automation.ui.support.util.ExpectedConditionsUtil;
 import com.taf.automation.ui.support.util.Helper;
 import com.taf.automation.ui.support.util.JsUtils;
 import com.taf.automation.ui.support.util.Utils;
@@ -15,6 +16,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
@@ -61,7 +63,7 @@ public abstract class GenericTable<T extends GenericRow> extends PageObjectV2 {
 
         String randomBaseValue = getRandomBaseValue();
         Map<String, String> substitutions = getSubstitutions();
-        List<WebElement> all = Utils.until(ExpectedConditions.numberOfElementsToBeMoreThan(getAllRowsLocator(), 0));
+        List<WebElement> all = Utils.until(ExpectedConditionsUtil.numberOfElementsToBeMoreThan(getAllRowsLocator(), 0, getIncludePredicate()));
         for (int i = 0; i < all.size(); i++) {
             // If necessary, we will make the row unique
             String randomIdValue = randomBaseValue + i;
@@ -300,6 +302,21 @@ public abstract class GenericTable<T extends GenericRow> extends PageObjectV2 {
     protected String getAttributeToExtractRowKey() {
         // Normally, the id attribute will be unique if it exists
         return JsUtils.ID;
+    }
+
+    /**
+     * Get the predicate used to test if a row should be included.<BR>
+     * <B>Notes: </B>
+     * <OL>
+     * <LI>The default implementation returns a predicate that includes all rows</LI>
+     * <LI>This should be only used if a locator to find only the rows is not possible and
+     * some additional test is needed to determine if the row should be included</LI>
+     * </OL>
+     *
+     * @return the predicate used to test if a row should be included
+     */
+    protected Predicate<WebElement> getIncludePredicate() {
+        return element -> true;
     }
 
     /**


### PR DESCRIPTION
Based on the structure of the HTML it may not be possible to write a locator that only gets the rows.  (You might get hidden rows or the header rows, etc.)  So, I have added support to filter the rows once they are retrieved.  I did not use this criteria prior to the no rows check mainly for performance reasons.  The default behavior is to include all rows as such no code changes are required for existing tables.