### PR TITLE
Enhanced Failure Grouping in Allure Report on the Categories tab

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/FailureGroupingTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/FailureGroupingTest.java
@@ -1,0 +1,56 @@
+package com.automation.common.ui.app.tests;
+
+import com.taf.automation.ui.support.testng.TestNGBase;
+import org.openqa.selenium.By;
+import org.testng.annotations.Test;
+import ru.yandex.qatools.allure.annotations.Features;
+import ru.yandex.qatools.allure.annotations.Severity;
+import ru.yandex.qatools.allure.annotations.Step;
+import ru.yandex.qatools.allure.annotations.Stories;
+import ru.yandex.qatools.allure.model.SeverityLevel;
+
+/**
+ * This class contains tests that will fail to test the Allure Failure Grouping on Categories tab
+ */
+public class FailureGroupingTest extends TestNGBase {
+    private static final By FAILURE_GROUP_1 = By.id("Failure Group 1");
+    private static final By FAILURE_GROUP_2 = By.cssSelector("[data='Failure Group 1']");
+
+    @Features("AllureTestNGListener")
+    @Stories("Group 1 - Validate that the build info is removed such that failure groups occur on similar exceptions")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void failure1forGroup1() {
+        performSomeActionThatFails(FAILURE_GROUP_1);
+    }
+
+    @Features("AllureTestNGListener")
+    @Stories("Group 2 - Validate that the build info is removed such that failure groups occur on similar exceptions")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void failure1forGroup2() {
+        performSomeActionThatFails(FAILURE_GROUP_2);
+    }
+
+    @Features("AllureTestNGListener")
+    @Stories("Group 1 - Validate that the build info is removed such that failure groups occur on similar exceptions")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void failure2forGroup1() {
+        performSomeActionThatFails(FAILURE_GROUP_1);
+    }
+
+    @Features("AllureTestNGListener")
+    @Stories("Group 2 - Validate that the build info is removed such that failure groups occur on similar exceptions")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void failure2forGroup2() {
+        performSomeActionThatFails(FAILURE_GROUP_2);
+    }
+
+    @Step("Perform Some Action That Fails")
+    private void performSomeActionThatFails(By locator) {
+        getContext().getDriver().findElement(locator);
+    }
+
+}

--- a/automation-tests/src/main/resources/suites/FrameworkSmokeTestSuite.xml
+++ b/automation-tests/src/main/resources/suites/FrameworkSmokeTestSuite.xml
@@ -388,6 +388,12 @@
         </classes>
     </test>
 
+    <test name="Failure Grouping Test">
+        <classes>
+            <class name="com.automation.common.ui.app.tests.FailureGroupingTest"/>
+        </classes>
+    </test>
+
     <!--
     <test name="Open Report Test">
         <parameter name="allure-report" value="/target/allure-report"/>
@@ -443,15 +449,6 @@
     -->
 
     <!--
-    <test name="CSV List Test">
-        <parameter name="csv" value="data/ui/list-testing.csv"/>
-        <classes>
-            <class name="com.automation.common.ui.app.tests.CsvListTest"/>
-        </classes>
-    </test>
-    -->
-
-    <!--
     <test name="Masking Test">
         <parameter name="file" value="data/ui/testingExcel.xls"/>
         <parameter name="extension" value=".xls"/>
@@ -471,98 +468,10 @@
     -->
 
     <!--
-    <test name="Switch Dynamic Locator Test">
-        <parameter name="data-set" value="data/ui/TNHC_TestData.xml"/>
-        <classes>
-            <class name="com.automation.common.ui.app.tests.TNHC_Test">
-                <methods>
-                    <include name="dynamicLocatorSwitchingTest"/>
-                </methods>
-            </class>
-        </classes>
-    </test>
-
-    <test name="Dynamic Locator Test">
-        <parameter name="data-set" value="data/ui/TNHC_TestData.xml"/>
-        <classes>
-            <class name="com.automation.common.ui.app.tests.TNHC_Test">
-                <methods>
-                    <include name="dynamicLocatorTest"/>
-                </methods>
-            </class>
-        </classes>
-    </test>
-    -->
-
-    <!--
     <test name="Soap Get Holiday Date Test">
         <parameter name="data-soap-get-holiday-date" value="data/api/SoapGetHolidayDateTestData.xml"/>
         <classes>
             <class name="com.automation.common.api.tests.SoapHolidayTest"/>
-        </classes>
-    </test>
-    -->
-
-    <!--
-    <test name="Conditional Test">
-        <classes>
-            <class name="com.automation.common.ui.app.tests.ConditionalTest">
-                <methods>
-                    <include name="multipleCriteriaTest"/>
-                </methods>
-            </class>
-        </classes>
-    </test>
-    -->
-
-    <!--
-    <test name="True North Hockey Canada Test 1">
-        <parameter name="data-set" value="data/ui/TNHC_TestData.xml"/>
-        <classes>
-            <class name="com.automation.common.ui.app.tests.TNHC_Test"/>
-        </classes>
-    </test>
-
-    <test name="True North Hockey Canada Test 2">
-        <parameter name="data-set" value="data/ui/TNHC_TestData.xml"/>
-        <classes>
-            <class name="com.automation.common.ui.app.tests.TNHC_Test"/>
-        </classes>
-    </test>
-
-    <test name="True North Hockey Canada Test 3">
-        <parameter name="data-set" value="data/ui/TNHC_TestData.xml"/>
-        <classes>
-            <class name="com.automation.common.ui.app.tests.TNHC_Test">
-                <methods>
-                    <include name="generalUnitTest"/>
-                    <exclude name=".*"/>
-                </methods>
-            </class>
-        </classes>
-    </test>
-
-    <test name="True North Hockey Canada Test 4">
-        <parameter name="data-set" value="data/ui/TNHC_TestData.xml"/>
-        <classes>
-            <class name="com.automation.common.ui.app.tests.TNHC_Test">
-                <methods>
-                    <include name="generalUnitTest2"/>
-                    <exclude name=".*"/>
-                </methods>
-            </class>
-        </classes>
-    </test>
-
-    <test name="True North Hockey Canada Test 5">
-        <parameter name="data-set" value="data/ui/TNHC_TestData.xml"/>
-        <classes>
-            <class name="com.automation.common.ui.app.tests.TNHC_Test">
-                <methods>
-                    <include name="generalUnitTest3"/>
-                    <exclude name=".*"/>
-                </methods>
-            </class>
         </classes>
     </test>
     -->


### PR DESCRIPTION
Allure groups failures using the message & stacktrace.  However, all Selenium exceptions contain Build Info, System info, Driver info & Session ID which are basically always unique which prevents grouping the failures together.  So, this enhancement is to remove Build Info, System info, Driver info & Session ID such that the failures will be grouped together under the Categories tab which makes investigating/finding a common issue easier.  Also, I did some basic code cleanup.