### PR TITLE
Add basic support for a mutex across processes

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/CsvWriteTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/CsvWriteTest.java
@@ -1,15 +1,20 @@
 package com.automation.common.ui.app.tests;
 
+import com.taf.automation.locking.InterProcessBasicMutex;
 import com.taf.automation.ui.support.Rand;
 import com.taf.automation.ui.support.csv.CsvOutputRecord;
 import com.taf.automation.ui.support.csv.CsvUtils;
 import com.taf.automation.ui.support.testng.TestNGBase;
+import com.taf.automation.ui.support.util.Utils;
 import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
-import java.text.SimpleDateFormat;
+import java.io.File;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 /**
@@ -19,7 +24,7 @@ public class CsvWriteTest extends TestNGBase {
     private static final String[] HEADER_ROW = {"ROW", "First", "Last", "Phone"};
     private List<CsvOutputRecord> outputRecords;
 
-    private class OutputInfo implements CsvOutputRecord {
+    private static class OutputInfo implements CsvOutputRecord {
         private String row;
         private String first;
         private String last;
@@ -69,29 +74,49 @@ public class CsvWriteTest extends TestNGBase {
 
     }
 
-    private void createTestData() {
+    private void createTestData(String rowPrefix, int records, int delay) {
         outputRecords = new ArrayList<>();
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < records; i++) {
             OutputInfo item = new OutputInfo();
-            item.setRow("" + (i + 1));
+            item.setRow(rowPrefix + (i + 1));
             item.setFirst(Rand.letters(10));
             item.setLast(Rand.letters(20));
             item.setPhone(Rand.numbers(3) + "-" + Rand.numbers(3) + "-" + Rand.numbers(4));
             outputRecords.add(item);
+            Utils.sleep(delay);
         }
     }
 
     private void writeToCSV() {
-        CSVFormat format = CSVFormat.EXCEL.withHeader(HEADER_ROW);
-        SimpleDateFormat formatter = new SimpleDateFormat("hh_mm_ss");
-        String strDateStamp = formatter.format(new Date());
-        String filename = System.getProperty("user.dir") + System.getProperty("file.separator") + "test-csv-file-" + strDateStamp + ".csv";
-        CsvUtils.writeToCSV(filename, format, outputRecords);
+        CSVFormat format;
+        boolean append;
+        InterProcessBasicMutex mutex = new InterProcessBasicMutex();
+        mutex.lock();
+        try {
+            String filename = FilenameUtils.concat(System.getProperty("user.home"), "test-csv-file.csv");
+            File file = new File(filename);
+            if (file.exists()) {
+                format = CSVFormat.EXCEL.withSkipHeaderRecord();
+                append = true;
+            } else {
+                format = CSVFormat.EXCEL.withHeader(HEADER_ROW);
+                append = false;
+            }
+
+            CsvUtils.writeToCSV(filename, append, format, outputRecords);
+        } finally {
+            mutex.release();
+        }
     }
 
+    @Parameters({"row-prefix", "create-records", "delay"})
     @Test
-    public void performCsvWriteTest() {
-        createTestData();
+    public void performCsvWriteTest(
+            @Optional("") String rowPrefix,
+            @Optional("5") String createRecords,
+            @Optional("0") String delay
+    ) {
+        createTestData(rowPrefix, NumberUtils.toInt(createRecords), NumberUtils.toInt(delay));
         writeToCSV();
     }
 

--- a/taf/src/main/java/com/taf/automation/locking/InterProcessBasicMutex.java
+++ b/taf/src/main/java/com/taf/automation/locking/InterProcessBasicMutex.java
@@ -1,0 +1,194 @@
+package com.taf.automation.locking;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * This class provides an inter process basic mutex.  The main goal of this class is to allow multiple java processes
+ * that need to write to the same file without losing any changes.  For example, all your automation Jenkins jobs
+ * want to write something to a common file for the Jenkins slave.
+ */
+public class InterProcessBasicMutex {
+    private static final ReentrantLock access = new ReentrantLock(true);
+    private static final String DEFAULT_LOCK_FILE = "automation.lock";
+    private RandomAccessFile randomAccessFile;
+    private FileChannel channel;
+    private FileLock lock;
+    private boolean debuggingInfo;
+    private boolean exclusiveAccess;
+
+    private String directory;
+    private String lockFile;
+
+    public InterProcessBasicMutex() {
+        withEnabledThreadSafety();
+        withTempDirectory();
+        withDefaultLockFile();
+        withDebuggingInfoDisabled();
+    }
+
+    /**
+     * Enable thread safety if the same lock file will/could be used by multiple threads.<BR>
+     * <B>Notes: </B>
+     * <OL>
+     * <LI>This flag prevents the OverlappingFileLockException from occurring.</LI>
+     * <LI>There could be a performance impact if there are many uses of this class</LI>
+     * </OL>
+     *
+     * @return InterProcessBasicMutex
+     */
+    public InterProcessBasicMutex withEnabledThreadSafety() {
+        exclusiveAccess = true;
+        return this;
+    }
+
+    /**
+     * Disable thread safety if only single thread and/or different lock files are used for each thread.<BR>
+     * <B>Note: </B>
+     * <OL>
+     * <LI>Based on use of class with this flag, it is possible to get an OverlappingFileLockException.
+     * It is up to the developer to handle/prevent this.</LI>
+     * <LI>If there are many uses of this class, then the performance will/should be better.</LI>
+     * </OL>
+     *
+     * @return InterProcessBasicMutex
+     */
+    public InterProcessBasicMutex withDisabledThreadSafety() {
+        exclusiveAccess = false;
+        return this;
+    }
+
+    public InterProcessBasicMutex withExclusiveAccess() {
+        exclusiveAccess = true;
+        return this;
+    }
+
+    public InterProcessBasicMutex withTempDirectory() {
+        directory = FileUtils.getTempDirectory().getAbsolutePath();
+        return this;
+    }
+
+    public InterProcessBasicMutex withUserDirectory() {
+        this.directory = FileUtils.getUserDirectory().getAbsolutePath();
+        return this;
+    }
+
+    public InterProcessBasicMutex withWorkingDirectory() {
+        this.directory = new File(System.getProperty("user.dir")).getAbsolutePath();
+        return this;
+    }
+
+    public InterProcessBasicMutex withDefaultLockFile() {
+        lockFile = DEFAULT_LOCK_FILE;
+        return this;
+    }
+
+    public InterProcessBasicMutex withLockFile(String filename) {
+        lockFile = filename;
+        return this;
+    }
+
+    public InterProcessBasicMutex withDirectory(String directory) {
+        this.directory = StringUtils.defaultString(directory);
+        return this;
+    }
+
+    public InterProcessBasicMutex withDebuggingInfoEnable() {
+        debuggingInfo = true;
+        return this;
+    }
+
+    public InterProcessBasicMutex withDebuggingInfoDisabled() {
+        debuggingInfo = false;
+        return this;
+    }
+
+    private RandomAccessFile getRandomAccessFile() {
+        if (randomAccessFile == null) {
+            try {
+                randomAccessFile = new RandomAccessFile(FilenameUtils.concat(directory, lockFile), "rw");
+            } catch (FileNotFoundException e) {
+                if (debuggingInfo) {
+                    e.printStackTrace();
+                }
+            }
+        }
+
+        return randomAccessFile;
+    }
+
+    @SuppressWarnings("java:S2259")
+    private FileChannel getFileChannel() {
+        if (channel == null) {
+            channel = getRandomAccessFile().getChannel();
+        }
+
+        return channel;
+    }
+
+    private void lockAccess() {
+        if (exclusiveAccess) {
+            access.lock();
+        }
+    }
+
+    private void unlockAccess() {
+        if (exclusiveAccess && access.isHeldByCurrentThread()) {
+            access.unlock();
+        }
+    }
+
+    /**
+     * @return true if lock was acquired successfully otherwise false
+     */
+    public boolean lock() {
+        try {
+            lockAccess();
+            lock = getFileChannel().lock();
+            return true;
+        } catch (NullPointerException npe) {
+            // the file channel was null which means the random access file threw an exception
+            // which is already output provided debugging was enabled
+        } catch (IOException e) {
+            if (debuggingInfo) {
+                e.printStackTrace();
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return true if the lock was released successfully otherwise false
+     */
+    public boolean release() {
+        if (lock != null) {
+            try {
+                if (lock.isValid()) {
+                    lock.release();
+                }
+            } catch (IOException e) {
+                if (debuggingInfo) {
+                    e.printStackTrace();
+                }
+
+                return false;
+            } finally {
+                unlockAccess();
+            }
+        }
+
+        unlockAccess();
+        return true;
+    }
+
+}

--- a/taf/src/main/java/com/taf/automation/locking/InterProcessBasicMutex.java
+++ b/taf/src/main/java/com/taf/automation/locking/InterProcessBasicMutex.java
@@ -67,11 +67,6 @@ public class InterProcessBasicMutex {
         return this;
     }
 
-    public InterProcessBasicMutex withExclusiveAccess() {
-        exclusiveAccess = true;
-        return this;
-    }
-
     public InterProcessBasicMutex withTempDirectory() {
         directory = FileUtils.getTempDirectory().getAbsolutePath();
         return this;


### PR DESCRIPTION
The main goal of this is to allow multiple java processes that need to write to the same file without losing any changes.  For example, all your automation Jenkins jobs want to write something to a common file for the Jenkins slave.

**Notes**:  
1. I could not find a simple library to do this.
1. I modified the CsvWriteTest for the unit testing.