### PR TITLE
Fix Deprecated Warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <vtd.version>2.11</vtd.version>
         <jackson.version>2.9.8</jackson.version>
         <apache.commons.version>3.11</apache.commons.version>
+        <apache.commons.text.version>1.3</apache.commons.text.version>
         <findbugs.version>3.0.1</findbugs.version>
         <consul.version>1.3.0</consul.version>
         <browser.mob.proxy.version>2.1.5</browser.mob.proxy.version>

--- a/taf/pom.xml
+++ b/taf/pom.xml
@@ -94,6 +94,11 @@
             <version>${apache.commons.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>${apache.commons.text.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.googlecode.page-component</groupId>
             <artifactId>ui_auto_core</artifactId>
             <version>${ui.auto.core.version}</version>

--- a/taf/src/main/java/com/taf/automation/api/mail/MailMessage.java
+++ b/taf/src/main/java/com/taf/automation/api/mail/MailMessage.java
@@ -1,6 +1,6 @@
 package com.taf.automation.api.mail;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import javax.mail.BodyPart;
 import javax.mail.Message;
@@ -16,8 +16,8 @@ import java.util.regex.Pattern;
  * Class to extract information from an e-mail message
  */
 public class MailMessage {
-    private final static Pattern USER_ACTIVATION_PATTERN = Pattern.compile("<a href=\"(.*?)\".*>Click here to confirm your email address.</a>");
-    private final String EMPTY_STRING = "";
+    private static final Pattern USER_ACTIVATION_PATTERN = Pattern.compile("<a href=\"(.*?)\".*>Click here to confirm your email address.</a>");
+    private static final String EMPTY_STRING = "";
 
     private final String to;
     private final String from;


### PR DESCRIPTION
**org.apache.commons.lang3.StringEscapeUtils** is deprecated and instead you are to use **org.apache.commons.text.StringEscapeUtils**