### PR TITLE
Re-factor cleaning exceptions & use onFailure

### DIFF
--- a/taf/src/main/java/com/taf/automation/ui/support/util/ExceptionUtils.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/util/ExceptionUtils.java
@@ -1,0 +1,58 @@
+package com.taf.automation.ui.support.util;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.reflect.ConstructorUtils;
+import org.openqa.selenium.WebDriverException;
+
+/**
+ * This class holds methods to work with exceptions
+ */
+public class ExceptionUtils {
+    private static final String BUILD_INFO = "Build info: version:" + RegExUtils.ANYTHING;
+    private static final String UUID = "\\(\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}\\)";
+
+    private ExceptionUtils() {
+        // Prevent initialization of class as all public methods should be static
+    }
+
+    /**
+     * Clean the exception message of the dynamic information which prevents allure from grouping properly
+     *
+     * @param message - message to clean
+     * @return message minus the problematic dynamic information
+     */
+    public static String clean(String message) {
+        return StringUtils.defaultString(message).replaceAll(BUILD_INFO, "").replaceAll(UUID, "");
+    }
+
+    /**
+     * Modify any WebDriverException to remove the dynamic information which prevents allure from grouping properly
+     *
+     * @param exception - Exception to clean/modify
+     * @return Throwable that is cleaned/modified if a type of WebDriverException
+     * otherwise the passed throwable exception is returned without modification
+     */
+    public static Throwable clean(Throwable exception) {
+        Class<? extends Throwable> clazz = exception.getClass();
+        if (!WebDriverException.class.isAssignableFrom(clazz)) {
+            return exception;
+        }
+
+        String cleanedMessage = clean(exception.getMessage());
+        Throwable modifiedException;
+
+        try {
+            // Create the same exception such that it is clear in the report the cause of the failure
+            modifiedException = ConstructorUtils.invokeConstructor(clazz, cleanedMessage, exception);
+        } catch (Exception ex) {
+            // As Fallback use the generic WebDriverException
+            modifiedException = new WebDriverException(cleanedMessage, exception);
+        }
+
+        // We don't want the current stacktrace which is just wrapping as such set to the original stacktrace
+        modifiedException.setStackTrace(exception.getStackTrace());
+
+        return modifiedException;
+    }
+
+}

--- a/taf/src/main/java/com/taf/automation/ui/support/util/Utils.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/util/Utils.java
@@ -2,7 +2,6 @@ package com.taf.automation.ui.support.util;
 
 import com.taf.automation.api.ApiUtils;
 import com.taf.automation.mobile.AppConfigBuilder;
-import com.taf.automation.ui.support.StringMod;
 import com.taf.automation.ui.support.TestContext;
 import com.taf.automation.ui.support.TestProperties;
 import com.taf.automation.ui.support.TextFileReader;
@@ -907,6 +906,7 @@ public class Utils {
      */
     public static WebElement clickWhenReady(WebElement element) {
         return Failsafe.with(getClickRetryPolicy())
+                .onFailure(ex -> assertThat(ExceptionUtils.clean(ex.getFailure().getMessage()), false))
                 .get(() -> {
                     until(ExpectedConditionsUtil.ready(element));
                     element.click();
@@ -922,6 +922,7 @@ public class Utils {
      */
     public static WebElement clickWhenReady(By locator) {
         return Failsafe.with(getClickRetryPolicy())
+                .onFailure(ex -> assertThat(ExceptionUtils.clean(ex.getFailure().getMessage()), false))
                 .get(() -> {
                     WebElement element = until(ExpectedConditionsUtil.ready(locator));
                     element.click();
@@ -938,6 +939,7 @@ public class Utils {
      */
     public static WebElement clickWhenReady(WebElement anchor, By relative) {
         return Failsafe.with(getClickRetryPolicy())
+                .onFailure(ex -> assertThat(ExceptionUtils.clean(ex.getFailure().getMessage()), false))
                 .get(() -> {
                     WebElement element = until(ExpectedConditionsUtil.ready(anchor, relative));
                     element.click();
@@ -986,7 +988,9 @@ public class Utils {
      * @param element - Element to click and wait for it to become stale
      */
     public static void clickAndWaitForStale(WebElement element) {
-        Failsafe.with(getClickRetryPolicy()).run(element::click);
+        Failsafe.with(getClickRetryPolicy())
+                .onFailure(ex -> assertThat(ExceptionUtils.clean(ex.getFailure().getMessage()), false))
+                .run(element::click);
         until(ExpectedConditions.stalenessOf(element));
     }
 
@@ -1435,7 +1439,7 @@ public class Utils {
             Duration interval = (Duration) ApiUtils.readField(FieldUtils.getField(FluentWait.class, "interval", true), wait);
             String timeoutMessage = String.format(
                     "Expected condition failed: waiting for %s (tried for %d second(s) with %d milliseconds interval)",
-                    new StringMod(isTrue.toString()).removeAll("Build info: version:" + RegExUtils.ANYTHING).get(),
+                    ExceptionUtils.clean(isTrue.toString()),
                     ObjectUtils.defaultIfNull(timeout, Duration.ofSeconds(getElementTimeout())).getSeconds(),
                     ObjectUtils.defaultIfNull(interval, Duration.ofMillis(100L)).toMillis()
             );
@@ -1445,7 +1449,7 @@ public class Utils {
             String errorMessage = String.format(
                     "Expected condition failed: waiting for %s %n%nDue to Exception: %n%n%s",
                     isTrue,
-                    new StringMod(ex.getMessage()).removeAll("Build info: version:" + RegExUtils.ANYTHING).get()
+                    ExceptionUtils.clean(ex.getMessage())
             );
             assertThat(errorMessage, false);
             return null;


### PR DESCRIPTION
- Move the exception cleaning to a separate class for re-usability
- Added the removal of the UUID from the exceptions as well (this makes click failures group together)
- Instead of catching retry failure switched to using build-in Failsafe way