### PR TITLE
Prevent possible stale element exceptions

### DIFF
--- a/taf/src/main/java/com/taf/automation/ui/support/util/Utils.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/util/Utils.java
@@ -1158,6 +1158,20 @@ public class Utils {
     }
 
     /**
+     * Get Polling RetryPolicy that can be used to poll for a specific condition that occurs within a small timeout<BR>
+     * <B>Notes:</B>
+     * <OL>
+     * <LI>The max duration is from the TestProperties class using the negative timeout</LI>
+     * <LI>The RetryPolicy can then be used with 'Failsafe.with' to poll for a specific condition</LI>
+     * </OL>
+     *
+     * @return RetryPolicy
+     */
+    public static RetryPolicy<Object> getNegativePollingRetryPolicy() {
+        return getPollingRetryPolicy(TestProperties.getInstance().getNegativeTimeout());
+    }
+
+    /**
      * Get Polling RetryPolicy that can be used to poll for a specific condition<BR>
      * <B>Note: </B> <BR>
      * 1)  The RetryPolicy can then be used with 'Failsafe.with' to poll for a specific condition<BR>


### PR DESCRIPTION
- Instantiation of the drop down with the constructor can cause a stale element exception
```
select = new Select(element);
```
- The call to super.setValue can make the triggers AJAX flag invalid if it takes multiple tries.  To workaround this, I have added a flag to re-check the triggers AJAX flag.  It is necessary to manually configure this
```
setElementValueV2(creditCardTypeFake, () -> creditCardTypeFake.useDefaultConfigForAJAX());
// OR
setElementValueV2(creditCardTypeFake, () -> creditCardTypeFake.enableRecheckTriggersAJAX());
```
- During re-checking of triggers AJAX, it is possible that drop down could be or become stale as such re-try was necessary
