### PR TITLE
Revert "Enhance performance when set is empty"

### DIFF
--- a/taf/src/main/java/com/taf/automation/api/ApiUtils.java
+++ b/taf/src/main/java/com/taf/automation/api/ApiUtils.java
@@ -289,9 +289,9 @@ public class ApiUtils {
      * This normally requires using XStreamAlias on each of the fields.</LI>
      * </OL>
      *
-     * @param xStream     - xStream to configure the aliases
-     * @param definedIn   - the type that declares the field
-     * @param aliasPrefix - the prefix to append to the fields (a colon will be added)
+     * @param xStream       - xStream to configure the aliases
+     * @param definedIn     - the type that declares the field
+     * @param aliasPrefix   - the prefix to append to the fields (a colon will be added)
      */
     public static void aliasField(XStream xStream, Class definedIn, String aliasPrefix) {
         aliasField(xStream, definedIn, aliasPrefix, new HashSet<>());
@@ -311,10 +311,6 @@ public class ApiUtils {
      * @param excludeFields - fields to exclude in the alias configuration
      */
     public static void aliasField(XStream xStream, Class definedIn, String aliasPrefix, Set<String> excludeFields) {
-        if (excludeFields.isEmpty()) {
-            return;
-        }
-
         for (Field item : FieldUtils.getAllFields(definedIn)) {
             if (!excludeFields.contains(item.getName())) {
                 xStream.aliasField(aliasPrefix + ":" + item.getName(), definedIn, item.getName());


### PR DESCRIPTION
Reverts dn0000001/test-automation#308 which has a logic error.  If the excludes set is empty, this means all fields need to be processed with any exceptions.  This code would skip everything if the excludes set was empty which is incorrect.