### PR TITLE
Add support to override the method name in the report

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/LambdaExpressionMatcherTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/LambdaExpressionMatcherTest.java
@@ -3,7 +3,9 @@ package com.automation.common.ui.app.tests;
 import com.automation.common.ui.app.pageObjects.AddRemoveElementsPage;
 import com.automation.common.ui.app.pageObjects.Navigation;
 import com.taf.automation.ui.support.testng.TestNGBase;
+import com.taf.automation.ui.support.util.DomainObjectUtils;
 import com.taf.automation.ui.support.util.Utils;
+import org.testng.ITestContext;
 import org.testng.annotations.Test;
 import ru.yandex.qatools.allure.annotations.Features;
 import ru.yandex.qatools.allure.annotations.Severity;
@@ -18,7 +20,8 @@ public class LambdaExpressionMatcherTest extends TestNGBase {
     @Stories("Conditional - LambdaExpressionMatch")
     @Severity(SeverityLevel.CRITICAL)
     @Test
-    public void performTest() {
+    public void performTest(ITestContext injectedContext) {
+        DomainObjectUtils.overwriteTestName(injectedContext);
         new Navigation(getContext()).toHerokuappElements(Utils.isCleanCookiesSupported());
         AddRemoveElementsPage addRemoveElementsPage = new AddRemoveElementsPage();
         addRemoveElementsPage.initPage(getContext());

--- a/taf/src/main/java/com/taf/automation/ui/support/util/DomainObjectUtils.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/util/DomainObjectUtils.java
@@ -2,6 +2,7 @@ package com.taf.automation.ui.support.util;
 
 import datainstiller.data.DataAliases;
 import datainstiller.data.DataPersistence;
+import org.testng.ITestContext;
 import ru.yandex.qatools.allure.Allure;
 import ru.yandex.qatools.allure.events.TestCaseEvent;
 import ru.yandex.qatools.allure.model.Description;
@@ -64,6 +65,12 @@ public class DomainObjectUtils {
                 context.setDescription(new Description().withType(DescriptionType.MARKDOWN).withValue(description));
             }
         });
+    }
+
+    public static void overwriteTestName(ITestContext context) {
+        DataAliases aliases = new DataAliases();
+        aliases.put("test-name", context.getCurrentXmlTest().getName());
+        overwriteTestParameters(aliases);
     }
 
 }


### PR DESCRIPTION
Sometimes you may not have the need for a test data file which is where this is normally overridden.  This method will use the test name in the suite file.

In the report it will be
```
Lambda Expression Matcher Test
```
instead of 
```
performTest
```
with the suite file
```
    <test name="Lambda Expression Matcher Test">
        <classes>
            <class name="com.automation.common.ui.app.tests.LambdaExpressionMatcherTest"/>
        </classes>
    </test>
```
