### PR TITLE
Allow parsing of the response into an entity to fail

### DIFF
--- a/taf/src/main/java/com/taf/automation/api/clients/JaxbResponse.java
+++ b/taf/src/main/java/com/taf/automation/api/clients/JaxbResponse.java
@@ -64,18 +64,11 @@ public class JaxbResponse<T> implements GenericHttpResponse<T> {
         }
     }
 
-    @SuppressWarnings("unchecked")
-    private <P> P getEntityFromXml(String entityName, String entityXML) {
-        JAXBElement<P> element;
-        try {
-            JAXBContext context = JAXBContext.newInstance(entityName);
-            Unmarshaller u = context.createUnmarshaller();
-            StringReader stringReader = new StringReader(entityXML);
-            element = (JAXBElement<P>) u.unmarshal(stringReader);
-        } catch (JAXBException e) {
-            return null;
-        }
-
+    private <P> P getEntityFromXml(String entityName, String entityXML) throws JAXBException {
+        JAXBContext context = JAXBContext.newInstance(entityName);
+        Unmarshaller u = context.createUnmarshaller();
+        StringReader stringReader = new StringReader(entityXML);
+        JAXBElement<P> element = (JAXBElement<P>) u.unmarshal(stringReader);
         return element.getValue();
     }
 

--- a/taf/src/main/java/com/taf/automation/api/clients/JsonResponse.java
+++ b/taf/src/main/java/com/taf/automation/api/clients/JsonResponse.java
@@ -26,7 +26,7 @@ public class JsonResponse<T> implements GenericHttpResponse<T> {
     private Header[] headers;
     private JsonBaseError apiError;
 
-    @SuppressWarnings({"unchecked", "squid:S00112"})
+    @SuppressWarnings("squid:S00112")
     public JsonResponse(CloseableHttpResponse response, Class<T> responseEntity) {
         status = response.getStatusLine();
         headers = response.getAllHeaders();
@@ -42,7 +42,7 @@ public class JsonResponse<T> implements GenericHttpResponse<T> {
                 if (status.getStatusCode() < 400) {
                     entity = getEntityFromJson(responseEntity, entityJSON);
                 } else {
-                    apiError = getEntityFromJson((Class<T>) JsonError.class, entityJSON);
+                    apiError = getEntityFromJson(JsonError.class, entityJSON);
                 }
             }
         } catch (Exception e) {
@@ -54,13 +54,8 @@ public class JsonResponse<T> implements GenericHttpResponse<T> {
         }
     }
 
-    @SuppressWarnings("unchecked")
-    private <P> P getEntityFromJson(Class<T> responseEntity, String entityJSON) {
-        try {
-            return (P) JsonUtils.getGson().fromJson(entityJSON, responseEntity);
-        } catch (Exception e) {
-            return null;
-        }
+    private <P> P getEntityFromJson(Class<P> responseEntity, String entityJSON) {
+        return JsonUtils.getGson().fromJson(entityJSON, responseEntity);
     }
 
     @Override

--- a/taf/src/main/java/com/taf/automation/api/clients/MicroServiceResponse.java
+++ b/taf/src/main/java/com/taf/automation/api/clients/MicroServiceResponse.java
@@ -21,6 +21,7 @@ public class MicroServiceResponse<T> implements GenericHttpResponse<T> {
     private Header[] headers;
     private JsonBaseError error;
 
+    @SuppressWarnings("squid:S00112")
     public MicroServiceResponse(CloseableHttpResponse response, Class<T> responseEntity) {
         status = response.getStatusLine();
         headers = response.getAllHeaders();
@@ -61,8 +62,8 @@ public class MicroServiceResponse<T> implements GenericHttpResponse<T> {
      * @param <P>            - same as response entity type
      * @return entity
      */
-    private <P> P getEntityFromJSON(Class responseEntity, String rawJSON) {
-        return (P) JsonUtils.getGson().fromJson(rawJSON, responseEntity);
+    private <P> P getEntityFromJSON(Class<P> responseEntity, String rawJSON) {
+        return JsonUtils.getGson().fromJson(rawJSON, responseEntity);
     }
 
     @Override

--- a/taf/src/main/java/com/taf/automation/api/clients/XmlResponse.java
+++ b/taf/src/main/java/com/taf/automation/api/clients/XmlResponse.java
@@ -73,9 +73,9 @@ public class XmlResponse<T> implements GenericHttpResponse<T> {
         }
     }
 
-    @SuppressWarnings({"unchecked", "squid:S1172"})
-    private <T> T getEntityFromXml(Class<T> responseEntity, String entityXML) {
-        return (T) getXstream().fromXML(entityXML);
+    @SuppressWarnings("squid:S1172")
+    private <P> P getEntityFromXml(Class<P> responseEntity, String entityXML) {
+        return (P) getXstream().fromXML(entityXML);
     }
 
     @Override


### PR DESCRIPTION
Previously any error would be swallowed up and just return null.  This behavior is probably undesired and an exception should thrown such that the user can know about any problems parsing the response into the entity.  (Assuming that actual validations were occurring on the entity to ensure the response was as expected, this should not affect the result but make determining the root cause easier when the response cannot be parsed into the entity.)