### PR TITLE
Add custom assertions for AssertJ

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/components/CreditCardFields.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/components/CreditCardFields.java
@@ -2,6 +2,7 @@ package com.automation.common.ui.app.components;
 
 import com.taf.automation.ui.support.ComponentPO;
 import com.taf.automation.ui.support.TestContext;
+import com.taf.automation.ui.support.util.AssertJUtil;
 import com.taf.automation.ui.support.util.Helper;
 import com.taf.automation.ui.support.util.JsUtils;
 import com.taf.automation.ui.support.util.Utils;
@@ -329,6 +330,31 @@ public class CreditCardFields extends ComponentPO {
     private void disableFieldAndValidateCreditCardTypeFake() {
         disableField(creditCardTypeFake);
         assertThat("Credit Card Type (Fake)", creditCardTypeFake, componentCannotBeSet(DISCOVER, this::configureCreditCardType));
+    }
+
+    @Step("Disable Fields And Validate Cannot Set using AssertJ")
+    public void disableFieldsAndValidateCannotSetAssertJ() {
+        disableFieldAndValidateCreditCardNumberAssertJ();
+        disableFieldAndValidateCreditCardTypeAssertJ();
+        disableFieldAndValidateCreditCardTypeFakeAssertJ();
+    }
+
+    @Step("Disable And Validate:  Credit Card Number using AssertJ")
+    private void disableFieldAndValidateCreditCardNumberAssertJ() {
+        disableField(creditCardNumber);
+        AssertJUtil.assertThat(creditCardNumber).as("Credit Card Number").cannotBeSetFast("1235");
+    }
+
+    @Step("Disable And Validate:  Credit Card Type using AssertJ")
+    private void disableFieldAndValidateCreditCardTypeAssertJ() {
+        disableField(creditCardType);
+        AssertJUtil.assertThat(creditCardType).as("Credit Card Type").cannotBeSet(DISCOVER, this::configureCreditCardType);
+    }
+
+    @Step("Disable And Validate:  Credit Card Type (Fake) using AssertJ")
+    private void disableFieldAndValidateCreditCardTypeFakeAssertJ() {
+        disableField(creditCardTypeFake);
+        AssertJUtil.assertThat(creditCardTypeFake).as("Credit Card Type (Fake)").cannotBeSet(DISCOVER, this::configureCreditCardType);
     }
 
 }

--- a/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/RoboFormLoginPage.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/RoboFormLoginPage.java
@@ -6,6 +6,7 @@ import com.automation.common.ui.app.components.CheckBoxLabel;
 import com.automation.common.ui.app.components.TextBox;
 import com.taf.automation.ui.support.PageObjectV2;
 import com.taf.automation.ui.support.TestContext;
+import com.taf.automation.ui.support.util.AssertJUtil;
 import com.taf.automation.ui.support.util.JsUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -96,6 +97,49 @@ public class RoboFormLoginPage extends PageObjectV2 {
         makeCheckBoxVisible(rememberBasic.getLocator());
         disableField(rememberBasic);
         assertThat("Remember (Basic)", rememberBasic, componentCannotBeSetFast(VALUE_TO_BE_SET));
+    }
+
+    @Step("Disable Fields And Validate Cannot Set using AssertJ")
+    public void disableFieldsAndValidateCannotSetAssertJ() {
+        disableFieldAndValidateEmailOrUserIdAssertJ();
+        disableFieldAndValidatePasswordAssertJ();
+        disableFieldAndValidateRememberLabelAssertJ();
+        disableFieldAndValidateRememberAJAXAssertJ();
+        disableFieldAndValidateRememberBasicAssertJ();
+    }
+
+    @Step("Disable And Validate:  Email Or User Id using AssertJ")
+    private void disableFieldAndValidateEmailOrUserIdAssertJ() {
+        disableField(emailOrUserId);
+        AssertJUtil.assertThat(emailOrUserId).as("Email Or User Id").cannotBeSetFast("1235");
+    }
+
+    @Step("Disable And Validate:  Password using AssertJ")
+    private void disableFieldAndValidatePasswordAssertJ() {
+        disableField(password);
+        AssertJUtil.assertThat(password).as("Password").cannotBeSetFast("67890");
+    }
+
+    @Step("Disable And Validate:  Remember (Label) using AssertJ")
+    private void disableFieldAndValidateRememberLabelAssertJ() {
+        disableField(rememberLabel.getInput());
+        AssertJUtil.assertThat(rememberLabel).as("Remember (Label)").cannotBeSetFast(VALUE_TO_BE_SET);
+    }
+
+    @Step("Disable And Validate:  Remember (AJAX) using AssertJ")
+    private void disableFieldAndValidateRememberAJAXAssertJ() {
+        // On this page the element is considered hidden, it is necessary to make it displayed for the test
+        makeCheckBoxVisible(rememberAJAX.getLocator());
+        disableField(rememberAJAX);
+        AssertJUtil.assertThat(rememberAJAX).as("Remember (AJAX)").cannotBeSetFast(VALUE_TO_BE_SET);
+    }
+
+    @Step("Disable And Validate:  Remember (Basic) using AssertJ")
+    private void disableFieldAndValidateRememberBasicAssertJ() {
+        // On this page the element is considered hidden, it is necessary to make it displayed for the test
+        makeCheckBoxVisible(rememberBasic.getLocator());
+        disableField(rememberBasic);
+        AssertJUtil.assertThat(rememberBasic).as("Remember (Basic)").cannotBeSetFast(VALUE_TO_BE_SET);
     }
 
 }

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/AssertJTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/AssertJTest.java
@@ -1,0 +1,832 @@
+package com.automation.common.ui.app.tests;
+
+import com.automation.common.ui.app.components.CreditCardFields;
+import com.automation.common.ui.app.components.UnitTestComponent;
+import com.automation.common.ui.app.components.UnitTestWebElement;
+import com.automation.common.ui.app.pageObjects.FakeComponentsPage;
+import com.automation.common.ui.app.pageObjects.Navigation;
+import com.automation.common.ui.app.pageObjects.RoboFormLoginPage;
+import com.taf.automation.asserts.AssertJCondition;
+import com.taf.automation.asserts.CustomSoftAssertions;
+import com.taf.automation.ui.support.testng.TestNGBase;
+import com.taf.automation.ui.support.util.AssertJUtil;
+import com.taf.automation.ui.support.util.ExpectedConditionsUtil;
+import com.taf.automation.ui.support.util.Helper;
+import com.taf.automation.ui.support.util.Utils;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.testng.annotations.Test;
+import ru.yandex.qatools.allure.annotations.Features;
+import ru.yandex.qatools.allure.annotations.Severity;
+import ru.yandex.qatools.allure.annotations.Stories;
+import ru.yandex.qatools.allure.model.SeverityLevel;
+import ui.auto.core.components.WebComponent;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.Locale;
+
+public class AssertJTest extends TestNGBase {
+    private static final String DEC_12_31_2018 = "12/31/2018";
+    private static final String DATE_PATTERN = "MM/dd/yyyy";
+
+    @SuppressWarnings("squid:S1068")
+    private static class TestObj {
+        private String fieldString1;
+        private String fieldString2;
+        private Integer fieldInteger1;
+        private Integer fieldInteger2;
+        private int fieldInt1;
+        private int fieldInt2;
+        private Boolean fieldBoolean1;
+        private Boolean fieldBoolean2;
+        private boolean fieldBool1;
+        private boolean fieldBool2;
+
+        public String getFieldString1() {
+            return fieldString1;
+        }
+
+        public String getFieldString2() {
+            return fieldString2;
+        }
+
+    }
+
+    @SuppressWarnings("java:S112")
+    @Features("AssertJUtil")
+    @Stories("WebElement is displayed assert with null element")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void assertIsDisplayedWithElementDoesNotExistTest() {
+        try {
+            WebElement actual = null;
+            AssertJUtil.assertThat(actual).isDisplayed();
+            throw new RuntimeException("Assertion did not fail:  assertIsDisplayedWithElementDoesNotExistTest");
+        } catch (AssertionError ae) {
+            Helper.log("Assertion failed as expected (assertIsDisplayedWithElementDoesNotExistTest)", true);
+        }
+    }
+
+    @Features("AssertJUtil")
+    @Stories("WebElement is displayed assert with element that exists")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void assertIsDisplayedWithElementExistTest() {
+        UnitTestWebElement element = new UnitTestWebElement().withDisplayed(true);
+        AssertJUtil.assertThat(element).isDisplayed();
+    }
+
+    @Features("AssertJUtil")
+    @Stories("By is displayed assert with element that exists")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void assertIsDisplayedWithByExistTest() {
+        new Navigation(getContext()).toTrueNorthHockey(Utils.isCleanCookiesSupported());
+        AssertJUtil.assertThat(getContext().getDriver()).isDisplayed(By.id("headersearch"));
+    }
+
+    @Features("AssertJUtil")
+    @Stories("WebElement is disabled assert with element that exists")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void assertIsDisabledWithElementExistTest() {
+        UnitTestWebElement element = new UnitTestWebElement().withEnabled(false);
+        AssertJUtil.assertThat(element).isDisabled();
+    }
+
+    @Features("AssertJUtil")
+    @Stories("WebElement is enabled assert with element that exists")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void assertIsEnabledWithElementExistTest() {
+        UnitTestWebElement element = new UnitTestWebElement().withEnabled(true);
+        AssertJUtil.assertThat(element).isEnabled();
+    }
+
+    @Features("AssertJUtil")
+    @Stories("By is enabled assert with element that exists")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void assertIsEnabledWithByExistTest() {
+        new Navigation(getContext()).toTrueNorthHockey(Utils.isCleanCookiesSupported());
+        AssertJUtil.assertThat(getContext().getDriver()).isEnabled(By.id("headersearch"));
+    }
+
+    @Features("AssertJUtil")
+    @Stories("WebComponent is enabled assert with element that exists")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void assertIsEnabledWithComponentExistTest() {
+        UnitTestComponent component = new UnitTestComponent().withEnabled(true);
+        AssertJUtil.assertThat(component).isEnabled();
+    }
+
+    @Features("AssertJUtil")
+    @Stories("WebComponent is disabled assert with element that exists")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void assertIsDisabledWithComponentExistTest() {
+        UnitTestComponent component = new UnitTestComponent().withEnabled(false);
+        AssertJUtil.assertThat(component).isDisabled();
+    }
+
+    @Features("AssertJUtil")
+    @Stories("WebComponent is displayed assert with element that exists")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void assertIsDisplayedWithComponentExistTest() {
+        UnitTestComponent component = new UnitTestComponent().withDisplayed(true);
+        AssertJUtil.assertThat(component).isDisplayed();
+    }
+
+    @Features("AssertJUtil")
+    @Stories("WebComponent is removed assert with element that exists")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void assertIsRemovedWithComponentExistTest() {
+        UnitTestComponent component = new UnitTestComponent().withDisplayed(false);
+        AssertJUtil.assertThat(component).isInvisible();
+    }
+
+    @Features("AssertJUtil")
+    @Stories("WebComponent is ready assert with element that exists")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void assertIsReadyWithComponentExistTest() {
+        UnitTestComponent component = new UnitTestComponent().withEnabled(true).withDisplayed(true);
+        AssertJUtil.assertThat(component).isClickable();
+    }
+
+    @Features("AssertJUtil")
+    @Stories("WebComponent is not ready assert with element that exists")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void assertIsNotReadyWithComponentExistTest() {
+        String reason = "Enabled (%s), Displayed (%s)";
+        UnitTestComponent component = new UnitTestComponent().withEnabled(false).withDisplayed(false);
+        AssertJUtil.assertThat(component).as(reason, false, false).isNotClickable();
+
+        component = new UnitTestComponent().withEnabled(true).withDisplayed(false);
+        AssertJUtil.assertThat(component).as(reason, true, false).isNotClickable();
+
+        component = new UnitTestComponent().withEnabled(false).withDisplayed(true);
+        AssertJUtil.assertThat(component).as(reason, false, true).isNotClickable();
+    }
+
+    @SuppressWarnings("java:S3252")
+    @Features("AssertJUtil")
+    @Stories("Validate Component Cannot Be Set Assertion")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void assertComponentCannotBeSetTest() {
+        new Navigation(getContext()).toDuckDuckGo(Utils.isCleanCookiesSupported());
+        String valueToUse = "Does not matter";
+        WebElement element = Utils.until(ExpectedConditionsUtil.ready(By.name("q")));
+        WebComponent realComponent = new WebComponent(element);
+        Helper.log("UnitTestComponent (ready) - start:  " + new Date(), true);
+        CustomSoftAssertions softly = new CustomSoftAssertions();
+        softly.assertThat(realComponent).as("UnitTestComponent (ready)").cannotBeSet(valueToUse);
+        AssertJUtil.assertThat(softly.allSuccessful())
+                .as("Expected to be able to set the UnitTestComponent when ready")
+                .isFalse();
+        Helper.log("UnitTestComponent (ready) - complete:  " + new Date(), true);
+
+        // This will always take timeout as it constantly tries to set the value until timeout occurs
+        UnitTestComponent component = new UnitTestComponent(element).withEnabled(false).withDisplayed(false);
+        AssertJUtil.assertThat(component).as("UnitTestComponent (not ready)").cannotBeSet(valueToUse);
+        Helper.log("UnitTestComponent (not ready) - complete:  " + new Date(), true);
+    }
+
+    @Features("AssertJUtil")
+    @Stories("Validate Component Cannot Be Set Assertion")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void assertComponentCannotBeSetFastTest() {
+        new Navigation(getContext()).toRoboFormFill(Utils.isCleanCookiesSupported());
+        CreditCardFields creditCardFields = new CreditCardFields(getContext());
+        creditCardFields.disableFieldsAndValidateCannotSetAssertJ();
+
+        new Navigation(getContext()).toRoboFormLogin(Utils.isCleanCookiesSupported());
+        RoboFormLoginPage roboFormLoginPage = new RoboFormLoginPage(getContext());
+        roboFormLoginPage.disableFieldsAndValidateCannotSetAssertJ();
+    }
+
+    @Features("AssertJUtil")
+    @Stories("WebComponent is not displayed assert using WebDriverWait")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void assertIsNotDisplayedUsingWebDriverWaitTest() {
+        FakeComponentsPage fakeComponentsPage = new FakeComponentsPage(getContext());
+        AssertJUtil.assertThat(fakeComponentsPage.getTextBoxComponent()).isInvisibleFast(getContext().getDriver());
+    }
+
+    @SuppressWarnings("java:S3252")
+    @Features("AssertJUtil")
+    @Stories("BigDecimal Assertions")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void testBigDecimalAssertions() {
+        BigDecimal infinite = null;
+        AssertJUtil.assertThat(infinite)
+                .as("All Infinite")
+                .is(AssertJCondition.range(null, null));
+        AssertJUtil.assertThat(infinite)
+                .as("Infinite Less than or equal to infinite")
+                .is(AssertJCondition.range(new BigDecimal("-1"), null));
+        AssertJUtil.assertThat(new BigDecimal("5"))
+                .as("Any number less than infinite")
+                .is(AssertJCondition.range(BigDecimal.ZERO, null));
+        AssertJUtil.assertThat(new BigDecimal("5"))
+                .as("Lower bound equal test")
+                .is(AssertJCondition.range(new BigDecimal("5"), null));
+        AssertJUtil.assertThat(infinite)
+                .as("Infinite Less than or equal to infinite #2")
+                .is(AssertJCondition.range(BigDecimal.ZERO, null));
+        AssertJUtil.assertThat(new BigDecimal("20"))
+                .as("Lower bound equal test #2")
+                .is(AssertJCondition.range(BigDecimal.ZERO, null));
+    }
+
+    @SuppressWarnings({"java:S3252", "java:S112"})
+    @Features("AssertJUtil")
+    @Stories("BigDecimal Assertion Failures")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void testBigDecimalAssertionFailuresInfiniteGreaterThanAnyNumber() {
+        try {
+            BigDecimal infinite = null;
+            AssertJUtil.assertThat(infinite)
+                    .as("InfiniteGreaterThanAnyNumber")
+                    .is(AssertJCondition.range(null, new BigDecimal("90")));
+            throw new RuntimeException("Assertion did not fail:  InfiniteGreaterThanAnyNumber");
+        } catch (AssertionError ae) {
+            Helper.log("Assertion failed as expected (InfiniteGreaterThanAnyNumber)", true);
+        }
+    }
+
+    @SuppressWarnings({"java:S3252", "java:S112"})
+    @Features("AssertJUtil")
+    @Stories("BigDecimal Assertion Failures")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void testBigDecimalAssertionFailuresAnyNumberNotInRangeOfInfinity() {
+        try {
+            AssertJUtil.assertThat(BigDecimal.ZERO)
+                    .as("AnyNumberNotInRangeOfInfinity")
+                    .is(AssertJCondition.range(null, null));
+            throw new RuntimeException("Assertion did not fail:  AnyNumberNotInRangeOfInfinity");
+        } catch (AssertionError ae) {
+            Helper.log("Assertion failed as expected (AnyNumberNotInRangeOfInfinity)", true);
+        }
+    }
+
+    @SuppressWarnings({"java:S3252", "java:S112"})
+    @Features("AssertJUtil")
+    @Stories("BigDecimal Assertion Failures")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void testBigDecimalAssertionFailuresInfiniteNotInNumberRange() {
+        try {
+            BigDecimal infinite = null;
+            AssertJUtil.assertThat(infinite)
+                    .as("InfiniteNotInNumberRange")
+                    .is(AssertJCondition.range(new BigDecimal("0"), new BigDecimal("10")));
+            throw new RuntimeException("Assertion did not fail:  InfiniteNotInNumberRange");
+        } catch (AssertionError ae) {
+            Helper.log("Assertion failed as expected (InfiniteNotInNumberRange)", true);
+        }
+    }
+
+    @SuppressWarnings({"java:S3252", "java:S112"})
+    @Features("AssertJUtil")
+    @Stories("BigDecimal Assertion Failures")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void testBigDecimalAssertionFailuresInfiniteAsLowerBoundAndNumberUpperBound() {
+        try {
+            AssertJUtil.assertThat(new BigDecimal("4"))
+                    .as("InfiniteAsLowerBoundAndNumberUpperBound")
+                    .is(AssertJCondition.range(null, new BigDecimal("333")));
+            throw new RuntimeException("Assertion did not fail:  InfiniteAsLowerBoundAndNumberUpperBound");
+        } catch (AssertionError ae) {
+            Helper.log("Assertion failed as expected (InfiniteAsLowerBoundAndNumberUpperBound)", true);
+        }
+    }
+
+    @SuppressWarnings({"java:S3252", "java:S112"})
+    @Features("AssertJUtil")
+    @Stories("BigDecimal Assertion Failures")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void testBigDecimalAssertionFailuresInfiniteAsLowerBoundAndNumberUpperBoundWithInfinite() {
+        try {
+            BigDecimal infinite = null;
+            AssertJUtil.assertThat(infinite).is(AssertJCondition.range(null, new BigDecimal("333")));
+            throw new RuntimeException("Assertion did not fail:  InfiniteAsLowerBoundAndNumberUpperBoundWithInfinite");
+        } catch (AssertionError ae) {
+            Helper.log("Assertion failed as expected (InfiniteAsLowerBoundAndNumberUpperBoundWithInfinite)", true);
+        }
+    }
+
+    @SuppressWarnings("java:S3252")
+    @Features("AssertJUtil")
+    @Stories("Range Primitive")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void testRangePrimitive() {
+        AssertJUtil.assertThat(0).as("Start").isBetween(0, 2);
+        AssertJUtil.assertThat(1).as("Middle").isBetween(0, 2);
+        AssertJUtil.assertThat(2).as("End").isBetween(0, 2);
+
+        int failures = 0;
+        CustomSoftAssertions softly = new CustomSoftAssertions();
+        softly.assertThat(3).as("Greater Than Range").isBetween(0, 2);
+        failures++;
+        AssertJUtil.assertThat(softly.getFailureCount()).as("Greater Than Range did not fail").isEqualTo(failures);
+
+        softly.assertThat(0).as("Less Than Range").isBetween(1, 3);
+        failures++;
+        AssertJUtil.assertThat(softly.getFailureCount()).as("Less Than Range did not fail").isEqualTo(failures);
+    }
+
+    @SuppressWarnings("java:S3252")
+    @Features("AssertJUtil")
+    @Stories("Range BigDecimal")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void testRangeBigDecimal() {
+        final BigDecimal TWO = Utils.parse("2", Locale.CANADA);
+        final BigDecimal THREE = Utils.parse("3", Locale.CANADA);
+        final BigDecimal FIVE = Utils.parse("5", Locale.CANADA);
+        final BigDecimal TEN_THOUSAND = Utils.parse("10000", Locale.CANADA);
+        final BigDecimal INFINITE = null;
+
+        AssertJUtil.assertThat(BigDecimal.ZERO).as("Start").is(AssertJCondition.range(BigDecimal.ZERO, BigDecimal.TEN));
+        AssertJUtil.assertThat(FIVE).as("Middle").is(AssertJCondition.range(BigDecimal.ZERO, BigDecimal.TEN));
+        AssertJUtil.assertThat(BigDecimal.TEN).as("End").is(AssertJCondition.range(BigDecimal.ZERO, BigDecimal.TEN));
+        AssertJUtil.assertThat(TEN_THOUSAND).as("0 to Infinite").is(AssertJCondition.range(BigDecimal.ZERO, INFINITE));
+        AssertJUtil.assertThat(INFINITE).as("Infinite range").is(AssertJCondition.range(INFINITE, INFINITE));
+
+        int failures = 0;
+        CustomSoftAssertions softly = new CustomSoftAssertions();
+
+        softly.assertThat(THREE).as("Greater Than Range").is(AssertJCondition.range(BigDecimal.ZERO, TWO));
+        failures++;
+        AssertJUtil.assertThat(softly.getFailureCount()).as("Greater Than Range did not fail").isEqualTo(failures);
+
+        softly.assertThat(BigDecimal.ZERO).as("Less Than Range").is(AssertJCondition.range(BigDecimal.ONE, THREE));
+        failures++;
+        AssertJUtil.assertThat(softly.getFailureCount()).as("Less Than Range did not fail").isEqualTo(failures);
+
+        softly.assertThat(TEN_THOUSAND).as("Invalid Infinite range").is(AssertJCondition.range(INFINITE, BigDecimal.ZERO));
+        failures++;
+        AssertJUtil.assertThat(softly.getFailureCount()).as("Invalid Infinite range did not fail").isEqualTo(failures);
+    }
+
+    @SuppressWarnings({"java:S3252", "java:S112"})
+    @Features("AssertJUtil")
+    @Stories("Range Primitives")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void verifyPrimitivesTest() {
+        final boolean actualBool = true;
+        final int actualInt = 10;
+        final Boolean actualBoolean = true;
+        final Integer actualInteger = 10;
+        final String actualString = "abc";
+
+        int failures = 0;
+        CustomSoftAssertions softly = new CustomSoftAssertions();
+
+        boolean expectedBool = true;
+        AssertJUtil.assertThat(actualBool).as("boolean match").is(AssertJCondition.isEqualToIgnoringNullFields(expectedBool));
+        softly.assertThat(actualBool).as("boolean match").is(AssertJCondition.isEqualToIgnoringNullFields(expectedBool));
+        try {
+            expectedBool = false;
+            softly.assertThat(actualBool).as("boolean mismatch").is(AssertJCondition.isEqualToIgnoringNullFields(expectedBool));
+            failures++;
+            AssertJUtil.assertThat(actualBool).as("boolean mismatch").is(AssertJCondition.isEqualToIgnoringNullFields(expectedBool));
+            throw new RuntimeException("Assertion did not fail:  boolean mismatch");
+        } catch (AssertionError ae) {
+            Helper.log("Assertion failed as expected (boolean mismatch)", true);
+        }
+
+        int expectedInt = 10;
+        AssertJUtil.assertThat(actualInt).as("int match").is(AssertJCondition.isEqualToIgnoringNullFields(expectedInt));
+        softly.assertThat(actualInt).as("int match").is(AssertJCondition.isEqualToIgnoringNullFields(expectedInt));
+        try {
+            expectedInt = 20;
+            softly.assertThat(actualInt).as("int mismatch").is(AssertJCondition.isEqualToIgnoringNullFields(expectedInt));
+            failures++;
+            AssertJUtil.assertThat(actualInt).as("int mismatch").is(AssertJCondition.isEqualToIgnoringNullFields(expectedInt));
+            throw new RuntimeException("Assertion did not fail:  int mismatch");
+        } catch (AssertionError ae) {
+            Helper.log("Assertion failed as expected (int mismatch)", true);
+        }
+
+        Boolean expectedBoolean = true;
+        AssertJUtil.assertThat(actualBoolean).as("Boolean match").is(AssertJCondition.isEqualToIgnoringNullFields(expectedBoolean));
+        softly.assertThat(actualBoolean).as("Boolean match").is(AssertJCondition.isEqualToIgnoringNullFields(expectedBoolean));
+
+        expectedBoolean = null;
+        AssertJUtil.assertThat(actualBoolean).as("Boolean skip").is(AssertJCondition.isEqualToIgnoringNullFields(expectedBoolean));
+        softly.assertThat(actualBoolean).as("Boolean skip").is(AssertJCondition.isEqualToIgnoringNullFields(expectedBoolean));
+        try {
+            expectedBoolean = false;
+            softly.assertThat(actualBoolean).as("Boolean mismatch").is(AssertJCondition.isEqualToIgnoringNullFields(expectedBoolean));
+            failures++;
+            AssertJUtil.assertThat(actualBoolean).as("Boolean mismatch").is(AssertJCondition.isEqualToIgnoringNullFields(expectedBoolean));
+            throw new RuntimeException("Assertion did not fail:  Boolean mismatch");
+        } catch (AssertionError ae) {
+            Helper.log("Assertion failed as expected (Boolean mismatch)", true);
+        }
+
+        try {
+            expectedBoolean = null;  // Re-using and passing as the actual parameter
+            softly.assertThat(expectedBoolean).as("Boolean mismatch actual null").is(AssertJCondition.isEqualToIgnoringNullFields(actualBoolean));
+            failures++;
+            AssertJUtil.assertThat(expectedBoolean).as("Boolean mismatch actual null").is(AssertJCondition.isEqualToIgnoringNullFields(actualBoolean));
+            throw new RuntimeException("Assertion did not fail:  Boolean mismatch actual null");
+        } catch (AssertionError ae) {
+            Helper.log("Assertion failed as expected (Boolean mismatch actual null)", true);
+        }
+
+        Integer expectedInteger = 10;
+        AssertJUtil.assertThat(actualInteger).as("Integer match").is(AssertJCondition.isEqualToIgnoringNullFields(expectedInteger));
+        softly.assertThat(actualInteger).as("Integer match").is(AssertJCondition.isEqualToIgnoringNullFields(expectedInteger));
+
+        expectedInteger = null;
+        AssertJUtil.assertThat(actualInteger).as("Integer skip").is(AssertJCondition.isEqualToIgnoringNullFields(expectedInteger));
+        softly.assertThat(actualInteger).as("Integer skip").is(AssertJCondition.isEqualToIgnoringNullFields(expectedInteger));
+        try {
+            expectedInteger = 20;
+            softly.assertThat(actualInteger).as("Integer mismatch").is(AssertJCondition.isEqualToIgnoringNullFields(expectedInteger));
+            failures++;
+            AssertJUtil.assertThat(actualInteger).as("Integer mismatch").is(AssertJCondition.isEqualToIgnoringNullFields(expectedInteger));
+            throw new RuntimeException("Assertion did not fail:  Integer mismatch");
+        } catch (AssertionError ae) {
+            Helper.log("Assertion failed as expected (Integer mismatch)", true);
+        }
+
+        try {
+            expectedInteger = null;  // Re-using and passing as the actual parameter
+            softly.assertThat(expectedInteger).as("Integer mismatch actual null").is(AssertJCondition.isEqualToIgnoringNullFields(actualInteger));
+            failures++;
+            AssertJUtil.assertThat(expectedInteger).as("Integer mismatch actual null").is(AssertJCondition.isEqualToIgnoringNullFields(actualInteger));
+            throw new RuntimeException("Assertion did not fail:  Integer mismatch actual null");
+        } catch (AssertionError ae) {
+            Helper.log("Assertion failed as expected (Integer mismatch actual null)", true);
+        }
+
+        String expectedString = "abc";
+        AssertJUtil.assertThat(actualString).as("String match").is(AssertJCondition.isEqualToIgnoringNullFields(expectedString));
+        softly.assertThat(actualString).as("String match").is(AssertJCondition.isEqualToIgnoringNullFields(expectedString));
+
+        expectedString = null;
+        AssertJUtil.assertThat(actualString).as("String skip").is(AssertJCondition.isEqualToIgnoringNullFields(expectedString));
+        softly.assertThat(actualString).as("String skip").is(AssertJCondition.isEqualToIgnoringNullFields(expectedString));
+        try {
+            expectedString = "bcd";
+            softly.assertThat(actualString).as("String mismatch").is(AssertJCondition.isEqualToIgnoringNullFields(expectedString));
+            failures++;
+            AssertJUtil.assertThat(actualString).as("String mismatch").is(AssertJCondition.isEqualToIgnoringNullFields(expectedString));
+            throw new RuntimeException("Assertion did not fail:  String mismatch");
+        } catch (AssertionError ae) {
+            Helper.log("Assertion failed as expected (String mismatch)", true);
+        }
+
+        try {
+            expectedString = null;  // Re-using and passing as the actual parameter
+            softly.assertThat(expectedString).as("String mismatch actual null").is(AssertJCondition.isEqualToIgnoringNullFields(actualString));
+            failures++;
+            AssertJUtil.assertThat(expectedString).as("String mismatch actual null").is(AssertJCondition.isEqualToIgnoringNullFields(actualString));
+            throw new RuntimeException("Assertion did not fail:  String mismatch actual null");
+        } catch (AssertionError ae) {
+            Helper.log("Assertion failed as expected (String mismatch actual null)", true);
+        }
+
+        AssertJUtil.assertThat(softly.getFailureCount()).as("Aggregator Failure Count").isEqualTo(failures);
+    }
+
+    @SuppressWarnings("java:S3252")
+    @Features("AssertJUtil")
+    @Stories("Date Greater Than")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void testDateGreaterThan() {
+        String expected = "12/29/2018";
+        AssertJUtil.assertThat(DEC_12_31_2018)
+                .as("testDateGreaterThan")
+                .is(AssertJCondition.dateGreaterThan(expected, DATE_PATTERN));
+    }
+
+    @SuppressWarnings("java:S3252")
+    @Features("AssertJUtil")
+    @Stories("BigDecimal Greater Than")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void testBigDecimalGreaterThan() {
+        BigDecimal actual = new BigDecimal("5.01");
+        BigDecimal expected = new BigDecimal("5");
+        AssertJUtil.assertThat(actual).as("testBigDecimalGreaterThan").isGreaterThan(expected);
+    }
+
+    @SuppressWarnings("java:S3252")
+    @Features("AssertJUtil")
+    @Stories("Date Greater Than Or Equal To")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void testDateGreaterThanOrEqualTo() {
+        String expected = "12/29/2018";
+        AssertJUtil.assertThat(DEC_12_31_2018)
+                .as("testDateGreaterThanOrEqualTo")
+                .is(AssertJCondition.dateGreaterThanOrEqualTo(expected, DATE_PATTERN));
+    }
+
+    @SuppressWarnings("java:S3252")
+    @Features("AssertJUtil")
+    @Stories("BigDecimal Greater Than Or Equal To")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void testBigDecimalGreaterThanOrEqualTo() {
+        BigDecimal actual = new BigDecimal("5.01");
+        BigDecimal expected = new BigDecimal("5");
+        AssertJUtil.assertThat(actual).as("testBigDecimalGreaterThanOrEqualTo").isGreaterThanOrEqualTo(expected);
+    }
+
+    @SuppressWarnings("java:S3252")
+    @Features("AssertJUtil")
+    @Stories("Date Less Than")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void testDateLessThan() {
+        String actual = "12/30/2018";
+        AssertJUtil.assertThat(actual).as("testDateLessThan").is(AssertJCondition.dateLessThan(DEC_12_31_2018, DATE_PATTERN));
+    }
+
+    @SuppressWarnings("java:S3252")
+    @Features("AssertJUtil")
+    @Stories("BigDecimal Less Than")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void testBigDecimalLessThan() {
+        BigDecimal actual = new BigDecimal("5");
+        BigDecimal expected = new BigDecimal("5.01");
+        AssertJUtil.assertThat(actual).as("testBigDecimalLessThan").isLessThan(expected);
+    }
+
+    @SuppressWarnings("java:S3252")
+    @Features("AssertJUtil")
+    @Stories("Date Less Than Or Equal To")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void testDateLessThanOrEqualTo() {
+        String actual = "12/30/2018";
+        AssertJUtil.assertThat(actual)
+                .as("testDateLessThanOrEqualTo")
+                .is(AssertJCondition.dateLessThanOrEqualTo(DEC_12_31_2018, DATE_PATTERN));
+    }
+
+    @SuppressWarnings("java:S3252")
+    @Features("AssertJUtil")
+    @Stories("BigDecimal Less Than Or Equal To")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void testBigDecimalLessThanOrEqualTo() {
+        BigDecimal actual = new BigDecimal("5");
+        BigDecimal expected = new BigDecimal("5.01");
+        AssertJUtil.assertThat(actual).as("testBigDecimalLessThanOrEqualTo").isLessThanOrEqualTo(expected);
+    }
+
+    @SuppressWarnings("java:S3252")
+    @Features("AssertJUtil")
+    @Stories("Date Equal To")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void testDateEqualTo() {
+        AssertJUtil.assertThat(DEC_12_31_2018)
+                .as("testDateEqualTo")
+                .is(AssertJCondition.dateEqualTo(DEC_12_31_2018, DATE_PATTERN));
+    }
+
+    @SuppressWarnings("java:S3252")
+    @Features("AssertJUtil")
+    @Stories("BigDecimal Equal To")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void testBigDecimalEqualTo() {
+        BigDecimal actual = new BigDecimal("5");
+        BigDecimal expected = new BigDecimal("5.00");
+        AssertJUtil.assertThat(actual).as("testBigDecimalEqualTo").isEqualByComparingTo(expected);
+    }
+
+    @SuppressWarnings({"java:S3252", "java:S112"})
+    @Features("AssertJUtil")
+    @Stories("Objects")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void verifyObjectsTest() {
+        CustomSoftAssertions softly = new CustomSoftAssertions();
+        int failures = 0;
+
+        TestObj actual = new TestObj();
+        actual.fieldString1 = "abc";
+        actual.fieldString2 = "xyz";
+        actual.fieldInteger1 = 1;
+        actual.fieldInteger2 = 2;
+        actual.fieldInt1 = 3;
+        actual.fieldInt2 = 4;
+        actual.fieldBoolean1 = true;
+        actual.fieldBoolean2 = false;
+        actual.fieldBool1 = true;
+        actual.fieldBool2 = false;
+
+        // All fields verified
+        TestObj expected = new TestObj();
+        expected.fieldString1 = "abc";
+        expected.fieldString2 = "xyz";
+        expected.fieldInteger1 = 1;
+        expected.fieldInteger2 = 2;
+        expected.fieldInt1 = 3;
+        expected.fieldInt2 = 4;
+        expected.fieldBoolean1 = true;
+        expected.fieldBoolean2 = false;
+        expected.fieldBool1 = true;
+        expected.fieldBool2 = false;
+
+        AssertJUtil.assertThat(actual).isEqualToIgnoringNullFields(expected);
+        softly.assertThat(actual).isEqualToIgnoringNullFields(expected);
+
+        // Some fields skipped
+        expected.fieldString1 = null;
+        expected.fieldString2 = "xyz";
+        expected.fieldInteger1 = 1;
+        expected.fieldInteger2 = null;
+        expected.fieldInt1 = 3;
+        expected.fieldInt2 = 4;
+        expected.fieldBoolean1 = null;
+        expected.fieldBoolean2 = false;
+        expected.fieldBool1 = true;
+        expected.fieldBool2 = false;
+
+        AssertJUtil.assertThat(actual).isEqualToIgnoringNullFields(expected);
+        softly.assertThat(actual).isEqualToIgnoringNullFields(expected);
+
+        // All fields verified, 1 failure
+        expected.fieldString1 = "abc";
+        expected.fieldString2 = "def";
+        expected.fieldInteger1 = 1;
+        expected.fieldInteger2 = 2;
+        expected.fieldInt1 = 3;
+        expected.fieldInt2 = 4;
+        expected.fieldBoolean1 = true;
+        expected.fieldBoolean2 = false;
+        expected.fieldBool1 = true;
+        expected.fieldBool2 = false;
+
+        try {
+            softly.assertThat(actual).isEqualToIgnoringNullFields(expected);
+            failures++;
+            AssertJUtil.assertThat(actual).isEqualToIgnoringNullFields(expected);
+            throw new RuntimeException("Assertion did not fail:  fieldString2");
+        } catch (AssertionError ae) {
+            Helper.log("Assertion failed as expected (fieldString2)", true);
+        }
+
+        try {
+            expected.fieldString2 = "xyz";
+            expected.fieldInteger1 = 10;
+
+            softly.assertThat(actual).isEqualToIgnoringNullFields(expected);
+            failures++;
+            AssertJUtil.assertThat(actual).isEqualToIgnoringNullFields(expected);
+            throw new RuntimeException("Assertion did not fail:  fieldInteger1");
+        } catch (AssertionError ae) {
+            Helper.log("Assertion failed as expected (fieldInteger1)", true);
+        }
+
+        try {
+            expected.fieldInteger1 = 1;
+            expected.fieldInt2 = 40;
+
+            softly.assertThat(actual).isEqualToIgnoringNullFields(expected);
+            failures++;
+            AssertJUtil.assertThat(actual).isEqualToIgnoringNullFields(expected);
+            throw new RuntimeException("Assertion did not fail:  fieldInt2");
+        } catch (AssertionError ae) {
+            Helper.log("Assertion failed as expected (fieldInt2)", true);
+        }
+
+        try {
+            expected.fieldInt2 = 4;
+            expected.fieldBoolean1 = false;
+
+            softly.assertThat(actual).isEqualToIgnoringNullFields(expected);
+            failures++;
+            AssertJUtil.assertThat(actual).isEqualToIgnoringNullFields(expected);
+            throw new RuntimeException("Assertion did not fail:  fieldBoolean1");
+        } catch (AssertionError ae) {
+            Helper.log("Assertion failed as expected (fieldBoolean1)", true);
+        }
+
+        try {
+            expected.fieldBoolean1 = true;
+            expected.fieldBool2 = true;
+
+            softly.assertThat(actual).isEqualToIgnoringNullFields(expected);
+            failures++;
+            AssertJUtil.assertThat(actual).isEqualToIgnoringNullFields(expected);
+            throw new RuntimeException("Assertion did not fail:  fieldBool2");
+        } catch (AssertionError ae) {
+            Helper.log("Assertion failed as expected (fieldBool2)", true);
+        }
+
+        expected.fieldBool2 = false;
+        AssertJUtil.assertThat(actual).isEqualToIgnoringNullFields(expected);
+
+        // All fields verified, multiple failures
+        try {
+            expected.fieldString2 = "def";
+            expected.fieldInteger2 = 20;
+            expected.fieldInt2 = 40;
+            expected.fieldBoolean2 = true;
+            expected.fieldBool1 = false;
+
+            softly.assertThat(actual).isEqualToIgnoringNullFields(expected);
+            failures++;
+            AssertJUtil.assertThat(actual).isEqualToIgnoringNullFields(expected);
+            throw new RuntimeException("Assertion did not fail:  multiple failures");
+        } catch (AssertionError ae) {
+            Helper.log("Assertion failed as expected (multiple failures)", true);
+        }
+
+        expected.fieldString2 = "xyz";
+        expected.fieldInteger2 = 2;
+        expected.fieldInt2 = 4;
+        expected.fieldBoolean2 = false;
+        expected.fieldBool1 = true;
+        AssertJUtil.assertThat(actual).isEqualToIgnoringNullFields(expected);
+
+        // Some fields skipped, 1 failure
+        try {
+            expected.fieldString1 = null;
+            expected.fieldString2 = "def";
+            expected.fieldInteger1 = null;
+            expected.fieldBoolean1 = null;
+
+            softly.assertThat(actual).isEqualToIgnoringNullFields(expected);
+            failures++;
+            AssertJUtil.assertThat(actual).isEqualToIgnoringNullFields(expected);
+            throw new RuntimeException("Assertion did not fail:  single failure with skip");
+        } catch (AssertionError ae) {
+            Helper.log("Assertion failed as expected (single failure with skip)", true);
+        }
+
+        expected.fieldString1 = "abc";
+        expected.fieldString2 = "xyz";
+        expected.fieldInteger1 = 1;
+        expected.fieldInteger2 = 2;
+        expected.fieldInt1 = 3;
+        expected.fieldInt2 = 4;
+        expected.fieldBoolean1 = true;
+        expected.fieldBoolean2 = false;
+        expected.fieldBool1 = true;
+        expected.fieldBool2 = false;
+        AssertJUtil.assertThat(actual).isEqualToIgnoringNullFields(expected);
+
+        // Some fields skipped, multiple failures
+        try {
+            expected.fieldString1 = null;
+            expected.fieldString2 = "def";
+            expected.fieldInteger1 = null;
+            expected.fieldInteger2 = 20;
+            expected.fieldInt2 = 40;
+            expected.fieldBoolean1 = null;
+            expected.fieldBoolean2 = true;
+            expected.fieldBool1 = false;
+
+            softly.assertThat(actual).isEqualToIgnoringNullFields(expected);
+            failures++;
+            AssertJUtil.assertThat(actual).isEqualToIgnoringNullFields(expected);
+            throw new RuntimeException("Assertion did not fail:  multiple failures with skip");
+        } catch (AssertionError ae) {
+            Helper.log("Assertion failed as expected (multiple failures with skip)", true);
+        }
+
+        expected.fieldString1 = "abc";
+        expected.fieldString2 = "xyz";
+        expected.fieldInteger1 = 1;
+        expected.fieldInteger2 = 2;
+        expected.fieldInt1 = 3;
+        expected.fieldInt2 = 4;
+        expected.fieldBoolean1 = true;
+        expected.fieldBoolean2 = false;
+        expected.fieldBool1 = true;
+        expected.fieldBool2 = false;
+        AssertJUtil.assertThat(actual).isEqualToIgnoringNullFields(expected);
+
+        AssertJUtil.assertThat(softly.getFailureCount()).as("Aggregator Failure Count").isEqualTo(failures);
+    }
+
+}

--- a/automation-tests/src/main/resources/suites/FrameworkSmokeTestSuite.xml
+++ b/automation-tests/src/main/resources/suites/FrameworkSmokeTestSuite.xml
@@ -48,6 +48,12 @@
         </classes>
     </test>
 
+    <test name="AssertJ Test">
+        <classes>
+            <class name="com.automation.common.ui.app.tests.AssertJTest"/>
+        </classes>
+    </test>
+
     <test name="Herokuapp Data Table Test">
         <classes>
             <class name="com.automation.common.ui.app.tests.HerokuappDataTableTest"/>

--- a/taf/src/main/java/com/taf/automation/asserts/AssertJCondition.java
+++ b/taf/src/main/java/com/taf/automation/asserts/AssertJCondition.java
@@ -1,0 +1,129 @@
+package com.taf.automation.asserts;
+
+import com.taf.automation.ui.support.DateActions;
+import com.taf.automation.ui.support.util.Utils;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.assertj.core.api.Condition;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Date;
+
+public class AssertJCondition {
+    private enum DateCompareType {
+        EQUAL_TO,
+        GREATER_THAN,
+        GREATER_THAN_OR_EQUAL_TO,
+        LESS_THAN,
+        LESS_THAN_OR_EQUAL_TO
+    }
+
+    private AssertJCondition() {
+        // Prevent initialization of class as all public methods should be static
+    }
+
+    public static <T> Condition<T> isEqualToIgnoringNullFields(T expected) {
+        String logExpected = "null";
+        if (expected != null) {
+            ToStringBuilder.setDefaultStyle(Utils.getDefaultStyle());
+            logExpected = ReflectionToStringBuilder.toString(expected);
+        }
+
+        String description = "actual (%s) to equal expected (" + logExpected + ")";
+        return new Condition<T>() {
+            @Override
+            public boolean matches(T value) {
+                if (expected == null) {
+                    return true;
+                }
+
+                String logActual = "null";
+                if (value != null) {
+                    ToStringBuilder.setDefaultStyle(Utils.getDefaultStyle());
+                    logActual = ReflectionToStringBuilder.toString(value);
+                }
+
+                as(description, logActual);
+                CustomSoftAssertions softly = new CustomSoftAssertions();
+                softly.assertThat(value).isEqualToIgnoringNullFields(expected);
+                return softly.allSuccessful();
+            }
+        };
+    }
+
+    public static Condition<BigDecimal> range(final BigDecimal min, final BigDecimal max) {
+        String logMin = (min == null) ? "infinite (null)" : min.toString();
+        String logMax = (max == null) ? "infinite (null)" : max.toString();
+        String description = "in the range [" + logMin + "," + logMax + "] but it was not";
+        return new Condition<BigDecimal>(description) {
+            @Override
+            public boolean matches(BigDecimal value) {
+                boolean lowerBound = Utils.compareTo(value, min) >= 0;
+                boolean upperBound = Utils.compareTo(value, max) <= 0;
+                return lowerBound && upperBound;
+            }
+        };
+    }
+
+    public static Condition<String> dateGreaterThan(final String expectedDate, final String... parsePatterns) {
+        return dateCompare(DateCompareType.GREATER_THAN, expectedDate, parsePatterns);
+    }
+
+    public static Condition<String> dateGreaterThanOrEqualTo(final String expectedDate, final String... parsePatterns) {
+        return dateCompare(DateCompareType.GREATER_THAN_OR_EQUAL_TO, expectedDate, parsePatterns);
+    }
+
+    public static Condition<String> dateLessThan(final String expectedDate, final String... parsePatterns) {
+        return dateCompare(DateCompareType.LESS_THAN, expectedDate, parsePatterns);
+    }
+
+    public static Condition<String> dateLessThanOrEqualTo(final String expectedDate, final String... parsePatterns) {
+        return dateCompare(DateCompareType.LESS_THAN_OR_EQUAL_TO, expectedDate, parsePatterns);
+    }
+
+    public static Condition<String> dateEqualTo(final String expectedDate, final String... parsePatterns) {
+        return dateCompare(DateCompareType.EQUAL_TO, expectedDate, parsePatterns);
+    }
+
+    private static Condition<String> dateCompare(
+            final DateCompareType dateCompareType,
+            final String expectedDate,
+            final String... parsePatterns
+    ) {
+        return new Condition<String>() {
+            @Override
+            public boolean matches(String value) {
+                Date actual = DateActions.parseDateStrictly(value, parsePatterns);
+                if (actual == null) {
+                    as("actual date (%s) could not be parsed", value);
+                    return false;
+                }
+
+                Date expected = DateActions.parseDateStrictly(expectedDate, parsePatterns);
+                if (expected == null) {
+                    as("expected date (%s) could not be parsed", expectedDate);
+                    return false;
+                }
+
+                if (dateCompareType == DateCompareType.GREATER_THAN) {
+                    as("greater than \"%s\" using parse patterns:  %s", expectedDate, Arrays.toString(parsePatterns));
+                    return actual.compareTo(expected) > 0;
+                } else if (dateCompareType == DateCompareType.GREATER_THAN_OR_EQUAL_TO) {
+                    as("greater than or equal to \"%s\" using parse patterns:  %s", expectedDate, Arrays.toString(parsePatterns));
+                    return actual.compareTo(expected) >= 0;
+                } else if (dateCompareType == DateCompareType.LESS_THAN) {
+                    as("less than \"%s\" using parse patterns:  %s", expectedDate, Arrays.toString(parsePatterns));
+                    return actual.compareTo(expected) < 0;
+                } else if (dateCompareType == DateCompareType.LESS_THAN_OR_EQUAL_TO) {
+                    as("less than or equal to \"%s\" using parse patterns:  %s", expectedDate, Arrays.toString(parsePatterns));
+                    return actual.compareTo(expected) <= 0;
+                } else {
+                    as("equal to \"%s\" using parse patterns:  %s", expectedDate, Arrays.toString(parsePatterns));
+                    return actual.compareTo(expected) == 0;
+                }
+            }
+        };
+    }
+
+}

--- a/taf/src/main/java/com/taf/automation/asserts/CustomSoftAssertions.java
+++ b/taf/src/main/java/com/taf/automation/asserts/CustomSoftAssertions.java
@@ -1,0 +1,42 @@
+package com.taf.automation.asserts;
+
+import org.assertj.core.api.SoftAssertions;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import ui.auto.core.pagecomponent.PageComponent;
+
+public class CustomSoftAssertions extends SoftAssertions {
+    public WebElementAssert assertThat(WebElement actual) {
+        return proxy(WebElementAssert.class, WebElement.class, actual);
+    }
+
+    public WebDriverAssert assertThat(WebDriver driver) {
+        return proxy(WebDriverAssert.class, WebDriver.class, driver);
+    }
+
+    public PageComponentAssert assertThat(PageComponent actual) {
+        return proxy(PageComponentAssert.class, PageComponent.class, actual);
+    }
+
+    /**
+     * @return true if there were any failures otherwise false
+     */
+    public boolean anyFailures() {
+        return !errorsCollected().isEmpty();
+    }
+
+    /**
+     * @return true if there were no failures otherwise false
+     */
+    public boolean allSuccessful() {
+        return errorsCollected().isEmpty();
+    }
+
+    /**
+     * @return the failure count
+     */
+    public int getFailureCount() {
+        return errorsCollected().size();
+    }
+
+}

--- a/taf/src/main/java/com/taf/automation/asserts/PageComponentAssert.java
+++ b/taf/src/main/java/com/taf/automation/asserts/PageComponentAssert.java
@@ -1,0 +1,605 @@
+package com.taf.automation.asserts;
+
+import com.taf.automation.ui.support.ComponentPO;
+import com.taf.automation.ui.support.util.ExpectedConditionsUtil;
+import com.taf.automation.ui.support.util.LocatorUtils;
+import com.taf.automation.ui.support.util.Utils;
+import net.jodah.failsafe.Failsafe;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.reflect.ConstructorUtils;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import ui.auto.core.data.DataTypes;
+import ui.auto.core.pagecomponent.PageComponent;
+
+import java.lang.reflect.Method;
+import java.util.function.Consumer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+
+@SuppressWarnings("java:S5803")
+public class PageComponentAssert extends AbstractAssert<PageComponentAssert, PageComponent> {
+    public PageComponentAssert(PageComponent actual) {
+        super(actual, PageComponentAssert.class);
+    }
+
+    public static PageComponentAssert assertThat(PageComponent actual) {
+        return new PageComponentAssert(actual);
+    }
+
+    /**
+     * Verifies that the component is displayed
+     *
+     * @return PageComponentAssert
+     */
+    public PageComponentAssert isDisplayed() {
+        isNotNull();
+
+        try {
+            if (!actual.isDisplayed()) {
+                throw new WebDriverException();
+            }
+        } catch (Exception | AssertionError ex) {
+            failWithMessage("Expected component to be displayed but was NOT");
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that the component is enabled
+     *
+     * @return PageComponentAssert
+     */
+    public PageComponentAssert isEnabled() {
+        isNotNull();
+
+        try {
+            if (!actual.isEnabled()) {
+                throw new WebDriverException();
+            }
+        } catch (Exception | AssertionError ex) {
+            failWithMessage("Expected component to be enabled but was disabled");
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that the component is disabled
+     *
+     * @return PageComponentAssert
+     */
+    public PageComponentAssert isDisabled() {
+        isNotNull();
+
+        try {
+            if (actual.isEnabled()) {
+                throw new WebDriverException();
+            }
+        } catch (Exception | AssertionError ex) {
+            failWithMessage("Expected component to be disabled but was enabled");
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that the component is invisible
+     *
+     * @return PageComponentAssert
+     */
+    public PageComponentAssert isInvisible() {
+        isNotNull();
+
+        boolean displayed;
+        try {
+            displayed = actual.isDisplayed();
+        } catch (Exception | AssertionError ex) {
+            displayed = false;
+        }
+
+        if (displayed) {
+            failWithMessage("Expected component to be invisible but was visible");
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that the component is clickable (enabled &amp; displayed)
+     *
+     * @return PageComponentAssert
+     */
+    public PageComponentAssert isClickable() {
+        isNotNull();
+
+        try {
+            if (!actual.isEnabled() || !actual.isDisplayed()) {
+                throw new WebDriverException();
+            }
+        } catch (Exception | AssertionError ex) {
+            failWithMessage("Expected component to be clickable but was NOT");
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that the component is NOT clickable
+     *
+     * @return PageComponentAssert
+     */
+    public PageComponentAssert isNotClickable() {
+        isNotNull();
+
+        try {
+            if (actual.isEnabled() && actual.isDisplayed()) {
+                throw new WebDriverException();
+            }
+        } catch (Exception | AssertionError ex) {
+            failWithMessage("Expected component to not be clickable but was it clickable");
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that the component has the specified attribute with specified value
+     *
+     * @return PageComponentAssert
+     */
+    public PageComponentAssert hasAttributeValue(String attr, String value) {
+        isNotNull();
+
+        try {
+            if (!StringUtils.equals(actual.getAttribute(attr), value)) {
+                throw new WebDriverException();
+            }
+        } catch (Exception | AssertionError ex) {
+            failWithMessage("Expected component to have attr <%s> value as <%s> but it did NOT", attr, value);
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that the component is displayed before timeout
+     *
+     * @return PageComponentAssert
+     */
+    public PageComponentAssert isDisplayedWait() {
+        isNotNull();
+
+        boolean displayed;
+        try {
+            Utils.until(ExpectedConditionsUtil.displayed(actual));
+            displayed = true;
+        } catch (Exception | AssertionError ex) {
+            displayed = false;
+        }
+
+        if (!displayed) {
+            failWithMessage("Expected component to be displayed before timeout but was NOT");
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that the component is displayed before negative timeout
+     *
+     * @return PageComponentAssert
+     */
+    public PageComponentAssert isDisplayedFast() {
+        isNotNull();
+
+        boolean displayed;
+        try {
+            Utils.until(ExpectedConditionsUtil.displayed(actual), true);
+            displayed = true;
+        } catch (Exception | AssertionError ex) {
+            displayed = false;
+        }
+
+        if (!displayed) {
+            failWithMessage("Expected component to be displayed before negative timeout");
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that the component is clickable before timeout
+     *
+     * @return PageComponentAssert
+     */
+    public PageComponentAssert isClickableWait() {
+        isNotNull();
+
+        boolean ready;
+        try {
+            Utils.until(ExpectedConditionsUtil.ready(actual));
+            ready = true;
+        } catch (Exception | AssertionError ex) {
+            ready = false;
+        }
+
+        if (!ready) {
+            failWithMessage("Expected component to be clickable before timeout but was NOT");
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that the component is clickable before negative timeout
+     *
+     * @return PageComponentAssert
+     */
+    public PageComponentAssert isClickableFast() {
+        isNotNull();
+
+        boolean ready;
+        try {
+            Utils.until(ExpectedConditionsUtil.ready(actual), true);
+            ready = true;
+        } catch (Exception | AssertionError ex) {
+            ready = false;
+        }
+
+        if (!ready) {
+            failWithMessage("Expected component to be clickable before negative timeout");
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that the component is invisible before timeout
+     *
+     * @param driver - WebDriver used to get the core element using the component's locator
+     * @return PageComponentAssert
+     */
+    public PageComponentAssert isInvisibleWait(WebDriver driver) {
+        isNotNull();
+
+        boolean invisible;
+        try {
+            invisible = Failsafe.with(Utils.getPollingRetryPolicy()).get(() -> returnWhenInvisible(driver));
+        } catch (Exception | AssertionError ex) {
+            invisible = false;
+        }
+
+        if (!invisible) {
+            failWithMessage("Expected element to be invisible before timeout");
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that the component is invisible before negative timeout
+     *
+     * @param driver - WebDriver used to get the core element using the component's locator
+     * @return PageComponentAssert
+     */
+    public PageComponentAssert isInvisibleFast(WebDriver driver) {
+        isNotNull();
+
+        boolean invisible;
+        try {
+            invisible = Failsafe.with(Utils.getNegativePollingRetryPolicy()).get(() -> returnWhenInvisible(driver));
+        } catch (Exception | AssertionError ex) {
+            invisible = false;
+        }
+
+        if (!invisible) {
+            failWithMessage("Expected element to be invisible before negative timeout");
+        }
+
+        return this;
+    }
+
+    private boolean returnWhenInvisible(WebDriver driver) {
+        // For performance, check if the element can be found first
+        WebElement coreElement;
+        try {
+            coreElement = driver.findElement(actual.getLocator());
+        } catch (Exception ex) {
+            coreElement = null;
+        }
+
+        if (coreElement == null) {
+            return true;
+        }
+
+        // For performance, ensure the core element is not displayed, then use the component
+        // specific method to ensure the component is not displayed.
+        if (!coreElement.isDisplayed() && !actual.isDisplayed()) {
+            return true;
+        }
+
+        Assertions.fail("Component was visible");
+        return false;
+    }
+
+    /**
+     * Verifies that the component is not clickable before timeout
+     *
+     * @param driver - WebDriver used to get the core element using the component's locator
+     * @return PageComponentAssert
+     */
+    public PageComponentAssert isNotClickableWait(WebDriver driver) {
+        isNotNull();
+
+        boolean success;
+        try {
+            success = Failsafe.with(Utils.getPollingRetryPolicy()).get(() -> returnWhenNotClickable(driver));
+        } catch (Exception | AssertionError ex) {
+            success = false;
+        }
+
+        if (!success) {
+            failWithMessage("Expected component to be not clickable before timeout but was NOT");
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that the component is clickable before negative timeout
+     *
+     * @param driver - WebDriver used to get the core element using the component's locator
+     * @return PageComponentAssert
+     */
+    public PageComponentAssert isNotClickableFast(WebDriver driver) {
+        isNotNull();
+
+        boolean success;
+        try {
+            success = Failsafe.with(Utils.getNegativePollingRetryPolicy()).get(() -> returnWhenNotClickable(driver));
+        } catch (Exception | AssertionError ex) {
+            success = false;
+        }
+
+        if (!success) {
+            failWithMessage("Expected component to be not clickable before negative timeout");
+        }
+
+        return this;
+    }
+
+    private boolean returnWhenNotClickable(WebDriver driver) {
+        // For performance, ensure the core element is displayed, then use the component
+        // specific method to check if the component is ready.
+        WebElement coreElement = driver.findElement(actual.getLocator());
+        if (coreElement.isDisplayed() && actual.isDisplayed() && actual.isEnabled()) {
+            Assertions.fail("Component was clickable");
+        }
+
+        return true;
+    }
+
+    /**
+     * Verifies that the component is disabled before timeout
+     *
+     * @param driver - WebDriver used to get the core element using the component's locator
+     * @return PageComponentAssert
+     */
+    public PageComponentAssert isDisabledWait(WebDriver driver) {
+        isNotNull();
+
+        boolean success;
+        try {
+            success = Failsafe.with(Utils.getPollingRetryPolicy()).get(() -> returnWhenDisabled(driver));
+        } catch (Exception | AssertionError ex) {
+            success = false;
+        }
+
+        if (!success) {
+            failWithMessage("Expected component to be disabled before timeout but it was enabled");
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that the component is disabled before negative timeout
+     *
+     * @param driver - WebDriver used to get the core element using the component's locator
+     * @return PageComponentAssert
+     */
+    public PageComponentAssert isDisabledFast(WebDriver driver) {
+        isNotNull();
+
+        boolean success;
+        try {
+            success = Failsafe.with(Utils.getNegativePollingRetryPolicy()).get(() -> returnWhenDisabled(driver));
+        } catch (Exception | AssertionError ex) {
+            success = false;
+        }
+
+        if (!success) {
+            failWithMessage("Expected component to be disabled before negative timeout but it was enabled");
+        }
+
+        return this;
+    }
+
+    @SuppressWarnings("java:S2259")
+    private boolean returnWhenDisabled(WebDriver driver) {
+        // For performance, check if the element can be found first
+        WebElement coreElement;
+        try {
+            coreElement = driver.findElement(actual.getLocator());
+        } catch (Exception ex) {
+            coreElement = null;
+        }
+
+        if (coreElement == null) {
+            Assertions.fail("Element could not be found");
+        }
+
+        // For performance, ensure the core element is disabled, then use the component
+        // specific method to ensure the component is disabled.
+        if (!coreElement.isEnabled() && !actual.isEnabled()) {
+            return true;
+        }
+
+        Assertions.fail("Component was enabled");
+        return false;
+    }
+
+    /**
+     * Verifies that the component cannot be set using the specified value<BR>
+     * <B>Notes:</B>
+     * <OL>
+     * <LI>This method does not consider validation.
+     * So, as long as the value can be set this is a failure even if the validation would fail.</LI>
+     * <LI>This method uses setElementValueV2 to set the value.
+     * If the setElementValueV2 method is successful, then this is considered a failure.  So, on unexpected failures
+     * you should check that the component is not checking if the value is already entered which could be considered a
+     * successful setting of the component</LI>
+     * <LI>This method should only be used to valid that an option cannot be set because it is not valid
+     * and not that it is disabled</LI>
+     * </OL>
+     *
+     * @param valueToUse - Value to use when attempting to set the component
+     * @return PageComponentAssert
+     */
+    @SuppressWarnings("java:S110")
+    public PageComponentAssert cannotBeSet(String valueToUse) {
+        isNotNull();
+
+        String restoreData = null;
+        String restoreInitialData = null;
+        String restoreExpectedData = null;
+
+        try {
+            restoreData = actual.getData(DataTypes.Data, false);
+            restoreInitialData = actual.getData(DataTypes.Initial, false);
+            restoreExpectedData = actual.getData(DataTypes.Expected, false);
+        } catch (Exception ex) {
+            // Could not get the restore data.  So just consider this a fail
+            failWithMessage("Could not get the restore data from the component");
+        }
+
+        boolean successful;
+        try {
+            // Initialize component data for the test
+            actual.initializeData(valueToUse, null, null);
+
+            // This is a workaround to access to a page object with implementing or using an existing one
+            ComponentPO page = new ComponentPO() {
+                @Override
+                public boolean hasData() {
+                    return false;
+                }
+
+                @Override
+                public void fill() {
+                    setElementValueV2(actual, null, 0);
+                }
+
+                @Override
+                public void validate() {
+                    //
+                }
+            };
+
+            // This should fail as component cannot be set
+            page.fill();
+
+            // If we reach here, then component could be set and this is a failure
+            successful = true;
+        } catch (Exception | AssertionError ex) {
+            successful = false;
+        } finally {
+            actual.initializeData(restoreData, restoreInitialData, restoreExpectedData);
+        }
+
+        if (successful) {
+            failWithMessage("Able to be set value for component but it should not have been allowed");
+        }
+
+        return this;
+    }
+
+    public PageComponentAssert cannotBeSetFast(String valueToUse) {
+        return cannotBeSet(valueToUse, doNothing -> { });
+    }
+
+    public PageComponentAssert cannotBeSet(String valueToUse, Consumer<PageComponent> actionBeforeSetValue) {
+        return cannotBeSet(valueToUse, actionBeforeSetValue, 3);
+    }
+
+    public PageComponentAssert cannotBeSet(String valueToUse, Consumer<PageComponent> actionBeforeSetValue, int attempts) {
+        isNotNull();
+
+        boolean successful = true;
+        int max = Math.max(1, attempts);
+        for (int i = 0; i < max; i++) {
+            successful = canSetComponent(valueToUse, actual, actionBeforeSetValue);
+            if (successful) {
+                break;
+            }
+        }
+
+        if (successful) {
+            failWithMessage("Able to be set value for component but it should not have been allowed");
+        }
+
+        return this;
+    }
+
+    @SuppressWarnings("java:S2259")
+    private boolean canSetComponent(String valueToUse, PageComponent component, Consumer<PageComponent> actionBeforeSetValue) {
+        PageComponent temp = getTempComponent(component);
+        try {
+            // Initialize component data for the test
+            temp.initializeData(valueToUse, null, null);
+
+            // Set Locator for AJAX components
+            LocatorUtils.setLocator(temp, component.getLocator());
+
+            // Execute Custom configuration of the component
+            actionBeforeSetValue.accept(temp);
+
+            // This should fail as component cannot be set
+            temp.setValue();
+
+            // If we reach here, then component could be set
+            return true;
+        } catch (Exception | AssertionError ex) {
+            // Component could not be set
+            return false;
+        }
+    }
+
+    @SuppressWarnings("java:S3011")
+    private PageComponent getTempComponent(final PageComponent component) {
+        PageComponent temp;
+        try {
+            WebElement core = Utils.until(ExpectedConditions.visibilityOfElementLocated(component.getLocator()), true);
+            temp = ConstructorUtils.invokeConstructor(component.getClass());
+            Method m = PageComponent.class.getDeclaredMethod("initComponent", WebElement.class);
+            m.setAccessible(true);
+            m.invoke(temp, core);
+        } catch (Exception ex) {
+            temp = null;
+        }
+
+        if (temp == null) {
+            failWithMessage("Unable to create temp component & initialize for set value");
+        }
+
+        return temp;
+    }
+
+}

--- a/taf/src/main/java/com/taf/automation/asserts/WebDriverAssert.java
+++ b/taf/src/main/java/com/taf/automation/asserts/WebDriverAssert.java
@@ -1,0 +1,252 @@
+package com.taf.automation.asserts;
+
+import com.taf.automation.ui.support.util.Utils;
+import org.assertj.core.api.AbstractAssert;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+@SuppressWarnings("java:S5803")
+public class WebDriverAssert extends AbstractAssert<WebDriverAssert, WebDriver> {
+    private static final String EXCEPTION_OCCURRED = " but the following exception occurred validating:  %s";
+
+    public WebDriverAssert(WebDriver driver) {
+        super(driver, WebDriverAssert.class);
+    }
+
+    public static WebDriverAssert assertThat(WebDriver driver) {
+        return new WebDriverAssert(driver);
+    }
+
+    private WebElement getWebElement(By locator) {
+        WebElement element;
+        try {
+            element = actual.findElement(locator);
+        } catch (Exception ex) {
+            element = null;
+        }
+
+        if (element == null) {
+            failWithMessage("Could not find element with locator:  %s", locator);
+        }
+
+        return element;
+    }
+
+    /**
+     * Verifies that using the locator an element is found and it is displayed
+     *
+     * @param locator - Locator to find element
+     * @return WebDriverAssert
+     */
+    @SuppressWarnings("java:S2259")
+    public WebDriverAssert isDisplayed(By locator) {
+        isNotNull();
+
+        WebElement element = getWebElement(locator);
+        try {
+            if (!element.isDisplayed()) {
+                failWithMessage("Expected element to be displayed but was NOT");
+            }
+        } catch (Exception ex) {
+            // Catch any WebDriver exception like a stale element exception
+            failWithMessage("Expected element to be displayed" + EXCEPTION_OCCURRED, ex.getMessage());
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that using the locator an element is found and it is enabled
+     *
+     * @param locator - Locator to find element
+     * @return WebDriverAssert
+     */
+    @SuppressWarnings("java:S2259")
+    public WebDriverAssert isEnabled(By locator) {
+        isNotNull();
+
+        WebElement element = getWebElement(locator);
+        try {
+            if (!element.isEnabled()) {
+                failWithMessage("Expected element to be enabled but was NOT");
+            }
+        } catch (Exception ex) {
+            // Catch any WebDriver exception like a stale element exception
+            failWithMessage("Expected element to be enabled" + EXCEPTION_OCCURRED, ex.getMessage());
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that using the locator an element is found and it is clickable (enabled &amp; displayed)
+     *
+     * @param locator - Locator to find element
+     * @return WebDriverAssert
+     */
+    @SuppressWarnings("java:S2259")
+    public WebDriverAssert isClickable(By locator) {
+        isNotNull();
+
+        WebElement element = getWebElement(locator);
+        try {
+            if (!element.isEnabled() || !element.isDisplayed()) {
+                failWithMessage("Expected element to be clickable but was NOT");
+            }
+        } catch (Exception ex) {
+            // Catch any WebDriver exception like a stale element exception
+            failWithMessage("Expected element to be clickable" + EXCEPTION_OCCURRED, ex.getMessage());
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that using the locator an element is found and it is displayed before timeout
+     *
+     * @param locator - Locator to find element
+     * @return WebDriverAssert
+     */
+    public WebDriverAssert isDisplayedWait(By locator) {
+        isNotNull();
+
+        boolean displayed;
+        try {
+            Utils.until(ExpectedConditions.visibilityOfElementLocated(locator));
+            displayed = true;
+        } catch (Exception | AssertionError ex) {
+            displayed = false;
+        }
+
+        if (!displayed) {
+            failWithMessage("Expected element to be displayed before timeout but was NOT");
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that using the locator an element is found and it is displayed before negative timeout
+     *
+     * @param locator - Locator to find element
+     * @return WebDriverAssert
+     */
+    public WebDriverAssert isDisplayedFast(By locator) {
+        isNotNull();
+
+        boolean displayed;
+        try {
+            Utils.until(ExpectedConditions.visibilityOfElementLocated(locator), true);
+            displayed = true;
+        } catch (Exception | AssertionError ex) {
+            displayed = false;
+        }
+
+        if (!displayed) {
+            failWithMessage("Expected element to be displayed before negative timeout");
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that using the locator an element is found and it is clickable before timeout
+     *
+     * @param locator - Locator to find element
+     * @return WebDriverAssert
+     */
+    public WebDriverAssert isClickableWait(By locator) {
+        isNotNull();
+
+        boolean ready;
+        try {
+            Utils.until(ExpectedConditions.elementToBeClickable(locator));
+            ready = true;
+        } catch (Exception | AssertionError ex) {
+            ready = false;
+        }
+
+        if (!ready) {
+            failWithMessage("Expected element to be clickable before timeout but was NOT");
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that using the locator an element is found and it is clickable before negative timeout
+     *
+     * @param locator - Locator to find element
+     * @return WebDriverAssert
+     */
+    public WebDriverAssert isClickableFast(By locator) {
+        isNotNull();
+
+        boolean ready;
+        try {
+            Utils.until(ExpectedConditions.elementToBeClickable(locator), true);
+            ready = true;
+        } catch (Exception | AssertionError ex) {
+            ready = false;
+        }
+
+        if (!ready) {
+            failWithMessage("Expected element to be clickable before negative timeout");
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that either the locator finds an element and it is invisible before timeout OR
+     * the element is not found before timeout
+     *
+     * @param locator - Locator to find element
+     * @return WebDriverAssert
+     */
+    public WebDriverAssert isInvisibleWait(By locator) {
+        isNotNull();
+
+        boolean invisible;
+        try {
+            Utils.until(ExpectedConditions.invisibilityOfElementLocated(locator));
+            invisible = true;
+        } catch (Exception | AssertionError ex) {
+            invisible = false;
+        }
+
+        if (!invisible) {
+            failWithMessage("Expected element to be invisible before timeout but was NOT");
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that either the locator finds an element and it is invisible before negative timeout OR
+     * the element is not found before negative timeout
+     *
+     * @param locator - Locator to find element
+     * @return WebDriverAssert
+     */
+    public WebDriverAssert isInvisibleFast(By locator) {
+        isNotNull();
+
+        boolean invisible;
+        try {
+            Utils.until(ExpectedConditions.invisibilityOfElementLocated(locator), true);
+            invisible = true;
+        } catch (Exception | AssertionError ex) {
+            invisible = false;
+        }
+
+        if (!invisible) {
+            failWithMessage("Expected element to be invisible before negative timeout");
+        }
+
+        return this;
+    }
+
+}

--- a/taf/src/main/java/com/taf/automation/asserts/WebElementAssert.java
+++ b/taf/src/main/java/com/taf/automation/asserts/WebElementAssert.java
@@ -1,0 +1,281 @@
+package com.taf.automation.asserts;
+
+import com.taf.automation.ui.support.util.Utils;
+import org.apache.commons.lang3.StringUtils;
+import org.assertj.core.api.AbstractAssert;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+@SuppressWarnings("java:S5803")
+public class WebElementAssert extends AbstractAssert<WebElementAssert, WebElement> {
+    private static final String EXCEPTION_OCCURRED = " but the following exception occurred validating:  %s";
+
+    public WebElementAssert(WebElement actual) {
+        super(actual, WebElementAssert.class);
+    }
+
+    public static WebElementAssert assertThat(WebElement actual) {
+        return new WebElementAssert(actual);
+    }
+
+    /**
+     * Verifies that the element is displayed
+     *
+     * @return WebElementAssert
+     */
+    public WebElementAssert isDisplayed() {
+        isNotNull();
+
+        try {
+            if (!actual.isDisplayed()) {
+                failWithMessage("Expected element to be displayed but was NOT");
+            }
+        } catch (Exception ex) {
+            // Catch any WebDriver exception like a stale element exception
+            failWithMessage("Expected element to be displayed" + EXCEPTION_OCCURRED, ex.getMessage());
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that the element is enabled
+     *
+     * @return WebElementAssert
+     */
+    public WebElementAssert isEnabled() {
+        isNotNull();
+
+        try {
+            if (!actual.isEnabled()) {
+                failWithMessage("Expected element to be enabled but was NOT");
+            }
+        } catch (Exception ex) {
+            // Catch any WebDriver exception like a stale element exception
+            failWithMessage("Expected element to be enabled" + EXCEPTION_OCCURRED, ex.getMessage());
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that the element is disabled
+     *
+     * @return WebElementAssert
+     */
+    public WebElementAssert isDisabled() {
+        isNotNull();
+
+        try {
+            if (actual.isEnabled()) {
+                throw new WebDriverException();
+            }
+        } catch (Exception | AssertionError ex) {
+            failWithMessage("Expected element to be disabled but was enabled");
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that the element is invisible
+     *
+     * @return WebElementAssert
+     */
+    public WebElementAssert isInvisible() {
+        isNotNull();
+
+        boolean displayed;
+        try {
+            displayed = actual.isDisplayed();
+        } catch (Exception | AssertionError ex) {
+            displayed = false;
+        }
+
+        if (displayed) {
+            failWithMessage("Expected element to be invisible but was visible");
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that the element is clickable (enabled &amp; displayed)
+     *
+     * @return WebElementAssert
+     */
+    public WebElementAssert isClickable() {
+        isNotNull();
+
+        try {
+            if (!actual.isEnabled() || !actual.isDisplayed()) {
+                failWithMessage("Expected element to be clickable but was NOT");
+            }
+        } catch (Exception ex) {
+            // Catch any WebDriver exception like a stale element exception
+            failWithMessage("Expected element to be clickable" + EXCEPTION_OCCURRED, ex.getMessage());
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that the element has the specified attribute with specified value
+     *
+     * @return WebElementAssert
+     */
+    public WebElementAssert hasAttributeValue(String attr, String value) {
+        isNotNull();
+
+        try {
+            if (!StringUtils.equals(actual.getAttribute(attr), value)) {
+                failWithMessage("Expected element to have attr <%s> value as <%s> but it did NOT", attr, value);
+            }
+        } catch (Exception ex) {
+            // Catch any WebDriver exception like a stale element exception
+            failWithMessage("Expected element to have attr <%s> value as <%s>" + EXCEPTION_OCCURRED, ex.getMessage());
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that the element is displayed before timeout
+     *
+     * @return WebElementAssert
+     */
+    public WebElementAssert isDisplayedWait() {
+        isNotNull();
+
+        boolean displayed;
+        try {
+            Utils.until(ExpectedConditions.visibilityOf(actual));
+            displayed = true;
+        } catch (Exception | AssertionError ex) {
+            displayed = false;
+        }
+
+        if (!displayed) {
+            failWithMessage("Expected element to be displayed before timeout but was NOT");
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that the element is displayed before negative timeout
+     *
+     * @return WebElementAssert
+     */
+    public WebElementAssert isDisplayedFast() {
+        isNotNull();
+
+        boolean displayed;
+        try {
+            Utils.until(ExpectedConditions.visibilityOf(actual), true);
+            displayed = true;
+        } catch (Exception | AssertionError ex) {
+            displayed = false;
+        }
+
+        if (!displayed) {
+            failWithMessage("Expected element to be displayed before negative timeout");
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that the element is clickable before timeout
+     *
+     * @return WebElementAssert
+     */
+    public WebElementAssert isClickableWait() {
+        isNotNull();
+
+        boolean ready;
+        try {
+            Utils.until(ExpectedConditions.elementToBeClickable(actual));
+            ready = true;
+        } catch (Exception | AssertionError ex) {
+            ready = false;
+        }
+
+        if (!ready) {
+            failWithMessage("Expected element to be clickable before timeout but was NOT");
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that the element is clickable before negative timeout
+     *
+     * @return WebElementAssert
+     */
+    public WebElementAssert isClickableFast() {
+        isNotNull();
+
+        boolean ready;
+        try {
+            Utils.until(ExpectedConditions.elementToBeClickable(actual), true);
+            ready = true;
+        } catch (Exception | AssertionError ex) {
+            ready = false;
+        }
+
+        if (!ready) {
+            failWithMessage("Expected element to be clickable before negative timeout");
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that the element is invisible before timeout
+     *
+     * @return WebElementAssert
+     */
+    public WebElementAssert isInvisibleWait() {
+        isNotNull();
+
+        boolean invisible;
+        try {
+            Utils.until(ExpectedConditions.invisibilityOf(actual));
+            invisible = true;
+        } catch (Exception | AssertionError ex) {
+            invisible = false;
+        }
+
+        if (!invisible) {
+            failWithMessage("Expected element to be invisible before timeout but was NOT");
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies that the element is invisible before negative timeout
+     *
+     * @return WebElementAssert
+     */
+    public WebElementAssert isInvisibleFast() {
+        isNotNull();
+
+        boolean invisible;
+        try {
+            Utils.until(ExpectedConditions.invisibilityOf(actual), true);
+            invisible = true;
+        } catch (Exception | AssertionError ex) {
+            invisible = false;
+        }
+
+        if (!invisible) {
+            failWithMessage("Expected element to be invisible before negative timeout");
+        }
+
+        return this;
+    }
+
+}

--- a/taf/src/main/java/com/taf/automation/ui/support/util/AssertJUtil.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/util/AssertJUtil.java
@@ -1,0 +1,24 @@
+package com.taf.automation.ui.support.util;
+
+import com.taf.automation.asserts.PageComponentAssert;
+import com.taf.automation.asserts.WebDriverAssert;
+import com.taf.automation.asserts.WebElementAssert;
+import org.assertj.core.api.Assertions;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import ui.auto.core.pagecomponent.PageComponent;
+
+public class AssertJUtil extends Assertions {
+    public static WebElementAssert assertThat(WebElement actual) {
+        return new WebElementAssert(actual);
+    }
+
+    public static WebDriverAssert assertThat(WebDriver driver) {
+        return new WebDriverAssert(driver);
+    }
+
+    public static PageComponentAssert assertThat(PageComponent actual) {
+        return new PageComponentAssert(actual);
+    }
+
+}


### PR DESCRIPTION
AssertJ is a better assertion library but we do not have the same custom Hamcrest assertions.  So, to be able to move to the AssertJ library I have added all the necessary custom assertions.

**Note**:  Some custom assertions may seem to be missing but they are covered by AssertJ out of the box.  However, if there are truly any missing custom assertions, then let me know and I will add them.