### PR TITLE
Enhancements to the custom assertions for AssertJ

### DIFF
--- a/taf/src/main/java/com/taf/automation/asserts/AssertJCondition.java
+++ b/taf/src/main/java/com/taf/automation/asserts/AssertJCondition.java
@@ -95,14 +95,13 @@ public class AssertJCondition {
             @Override
             public boolean matches(String value) {
                 Date actual = DateActions.parseDateStrictly(value, parsePatterns);
-                if (actual == null) {
-                    as("actual date (%s) could not be parsed", value);
-                    return false;
-                }
-
                 Date expected = DateActions.parseDateStrictly(expectedDate, parsePatterns);
-                if (expected == null) {
-                    as("expected date (%s) could not be parsed", expectedDate);
+                if (actual == null || expected == null) {
+                    String actualValue = (value == null) ? null : "\"" + value + "\"";
+                    String expectedValue = (expectedDate == null) ? null : "\"" + expectedDate + "\"";
+                    final String error = "able to parse actual <%s> & expected <%s>"
+                            + " into a date for comparison using parse patterns:  %s";
+                    as(error, actualValue, expectedValue, Arrays.toString(parsePatterns));
                     return false;
                 }
 

--- a/taf/src/main/java/com/taf/automation/asserts/CustomSoftAssertions.java
+++ b/taf/src/main/java/com/taf/automation/asserts/CustomSoftAssertions.java
@@ -1,11 +1,14 @@
 package com.taf.automation.asserts;
 
+import com.taf.automation.ui.support.util.AssertJUtil;
 import org.assertj.core.api.SoftAssertions;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import ui.auto.core.pagecomponent.PageComponent;
 
 public class CustomSoftAssertions extends SoftAssertions {
+    private int storedFailureCount;
+
     public WebElementAssert assertThat(WebElement actual) {
         return proxy(WebElementAssert.class, WebElement.class, actual);
     }
@@ -37,6 +40,28 @@ public class CustomSoftAssertions extends SoftAssertions {
      */
     public int getFailureCount() {
         return errorsCollected().size();
+    }
+
+    /**
+     * Store the failure count for later with the expectation that a failure will have occurred
+     *
+     * @return CustomSoftAssertions
+     */
+    public CustomSoftAssertions expectFailure() {
+        storedFailureCount = getFailureCount();
+        return this;
+    }
+
+    /**
+     * Verifies that at least 1 expected failure has occurred since the method expectFailure was called
+     *
+     * @return CustomSoftAssertions
+     * @throws AssertionError if there is not at least 1 expected failure
+     */
+    @SuppressWarnings("java:S3252")
+    public CustomSoftAssertions assertExpectedFailure() {
+        AssertJUtil.assertThat(getFailureCount()).as("Expected Failures").isGreaterThan(storedFailureCount);
+        return this;
     }
 
 }


### PR DESCRIPTION
- Update date parsing message on failure for AssertJ
- Add method to workaround no support for **not** in AssertJ where as Hamcrest as **Matchers.not**
- Add example of how to handle null checks on nested objects in an efficient manner using AssertJ

