### PR TITLE
Update libraries for JDK16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,8 @@
         <allure.version>1.4.19</allure.version>
         <aspectj.maven.plugin.version>1.12.1</aspectj.maven.plugin.version>
         <aspectj.version>1.9.2</aspectj.version>
-        <maven-assembly-plugin>2.6</maven-assembly-plugin>
+        <maven-compiler-plugin>3.8.1</maven-compiler-plugin>
+        <maven-assembly-plugin>3.3.0</maven-assembly-plugin>
         <guava.version>25.0-jre</guava.version>
         <selenium.version>3.141.59</selenium.version>
         <appium.version>7.3.0</appium.version>
@@ -54,7 +55,7 @@
         <maven.javadoc.plugin.version>3.0.1</maven.javadoc.plugin.version>
         <jexcelapi.version>2.6.12</jexcelapi.version>
         <commons.csv.version>1.6</commons.csv.version>
-        <fillo.version>1.18</fillo.version>
+        <fillo.version>1.21</fillo.version>
         <io.qameta.allure.version>2.13.5</io.qameta.allure.version>
         <zip4j.version>1.3.2</zip4j.version>
         <commons.io.version>2.6</commons.io.version>
@@ -69,7 +70,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>${maven-compiler-plugin}</version>
                 <configuration>
                     <source>${compiler.version}</source>
                     <target>${compiler.version}</target>


### PR DESCRIPTION
This will resolve any compile issues with JDK16 but any "Illegal reflective access" that occur at run-time will remain.  The "Illegal reflective access" issues are mainly coming from XStream, TestNG & AssertJ as they use reflection and it is not currently possible for these libraries to be fixed due to the nature of these use.

There is a workaround for JDK16 which may be removed in the future.  In the JVM options, add the following:
```
--illegal-access=warn
--add-opens java.base/java.lang=ALL-UNNAMED
--add-opens java.base/java.lang.reflect=ALL-UNNAMED
--add-opens java.base/java.text=ALL-UNNAMED
--add-opens java.base/java.util=ALL-UNNAMED
--add-opens java.desktop/java.awt.font=ALL-UNNAMED
--add-opens java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED
```
The illegal-access option will output any of the "Illegal reflective access" issues at run-time such that you might be able to fix them.  If you remove this option, then any "Illegal reflective access" will cause a failure.  

I resolved all the "Illegal reflective access" issues in the Framework Smoke Test Suite by adding the add-opens options.  So, the illegal-access option should not be necessary but it is better to be safe and use it until it is removed.

Additionally, with JDK16 running tests via the IDE & data generation will fail due to "Illegal reflective access".  It is necessary to add the options to perform these actions in the IDE after they fail the 1st time.  It should be possible to add these options as default to TestNG Template for run configs.