### PR TITLE
Add abstract class to generically handle radio buttons

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/components/PrimeFacesRadioButtonGroup.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/components/PrimeFacesRadioButtonGroup.java
@@ -1,97 +1,28 @@
 package com.automation.common.ui.app.components;
 
-import com.taf.automation.ui.support.util.LocatorUtils;
 import org.openqa.selenium.WebElement;
-import ui.auto.core.data.DataTypes;
-import ui.auto.core.pagecomponent.PageComponent;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Component to work with a PrimeFaces Radio Button Group
  */
-public class PrimeFacesRadioButtonGroup extends PageComponent {
-    private Map<String, String> substitutions;
-    private RadioButtonGroup<RadioOption> component;
-    private String componentData;
-    private String componentInitialData;
-    private String componentExpectedData;
-
+public class PrimeFacesRadioButtonGroup extends RadioButtons<RadioOption> {
     public PrimeFacesRadioButtonGroup() {
         super();
+
+        // Note:  Any code in the constructor must not cause the element to be bound
+        selection = RadioButtonGroup.Selection.REGEX; // Change the default selection method
     }
 
     public PrimeFacesRadioButtonGroup(WebElement element) {
         super(element);
-    }
 
-    private Map<String, String> getSubstitutions() {
-        if (substitutions == null) {
-            substitutions = new HashMap<>();
-        }
-
-        return substitutions;
-    }
-
-    public void setSubstitutions(Map<String, String> substitutions) {
-        this.substitutions = substitutions;
-        component.setSubstitutions(substitutions);
+        // Note:  Any code in the constructor must not cause the element to be bound
+        selection = RadioButtonGroup.Selection.REGEX; // Change the default selection method
     }
 
     @Override
-    protected void init() {
-        component = new RadioButtonGroup<>(getCoreElement());
-        component.setClazz(RadioOption.class);
-        component.setSelection(RadioButtonGroup.Selection.REGEX);
-        component.setSubstitutions(getSubstitutions());
-        initComponentDataVariables();
-        component.initializeData(componentData, componentInitialData, componentExpectedData);
-        LocatorUtils.setLocator(component, getLocator());
-    }
-
-    @Override
-    public void initializeData(String data, String initialData, String expectedData) {
-        componentData = data;
-        componentInitialData = initialData;
-        componentExpectedData = expectedData;
-        if (component != null) {
-            component.initializeData(componentData, componentInitialData, componentExpectedData);
-        }
-
-        super.initializeData(data, initialData, expectedData);
-    }
-
-    /**
-     * For performance reasons, only initialize the data once
-     */
-    private void initComponentDataVariables() {
-        if (componentData == null) {
-            componentData = getData(DataTypes.Data);
-        }
-
-        if (componentInitialData == null) {
-            componentInitialData = getData(DataTypes.Initial);
-        }
-
-        if (componentExpectedData == null) {
-            componentExpectedData = getData(DataTypes.Expected);
-        }
-    }
-
-    @Override
-    public void setValue() {
-        component.setValue();
-    }
-
-    @Override
-    public String getValue() {
-        return component.getValue();
-    }
-
-    @Override
-    public void validateData(DataTypes validationMethod) {
-        component.validateData(validationMethod);
+    protected Class<RadioOption> getClazz() {
+        return RadioOption.class;
     }
 
 }

--- a/automation-tests/src/main/java/com/automation/common/ui/app/components/RadioButtonGroup.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/components/RadioButtonGroup.java
@@ -62,7 +62,7 @@ public class RadioButtonGroup<T extends PageComponent> extends PageComponent {
         this.selection = selection;
     }
 
-    private T getInstanceOfT(WebElement option) {
+    protected T getInstanceOfT(WebElement option) {
         T component = null;
         String error = "Failed to invoke constructor using reflection due to error:  ";
 
@@ -84,7 +84,7 @@ public class RadioButtonGroup<T extends PageComponent> extends PageComponent {
         return staticLocator;
     }
 
-    private Map<String, String> getSubstitutions() {
+    protected Map<String, String> getSubstitutions() {
         if (substitutions == null) {
             substitutions = new HashMap<>();
         }
@@ -100,11 +100,11 @@ public class RadioButtonGroup<T extends PageComponent> extends PageComponent {
         this.staticLocator = null;
     }
 
-    private List<WebElement> getOptions() {
+    protected List<WebElement> getOptions() {
         return Utils.until(ExpectedConditions.numberOfElementsToBeMoreThan(getStaticLocator(), 0));
     }
 
-    private boolean isMatchedOption(String displayedText, String matchToData) {
+    protected boolean isMatchedOption(String displayedText, String matchToData) {
         if (selection == Selection.CONTAINS) {
             return StringUtils.contains(displayedText, matchToData);
         } else if (selection == Selection.REGEX) {

--- a/automation-tests/src/main/java/com/automation/common/ui/app/components/RadioButtons.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/components/RadioButtons.java
@@ -1,0 +1,140 @@
+package com.automation.common.ui.app.components;
+
+import com.taf.automation.ui.support.util.LocatorUtils;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import ui.auto.core.data.DataTypes;
+import ui.auto.core.pagecomponent.PageComponent;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Abstract class from which application specific components can be created to work with radio button options.
+ *
+ * @param <T> Type of options
+ */
+public abstract class RadioButtons<T extends PageComponent> extends PageComponent {
+    private Map<String, String> substitutions;
+    private RadioButtonGroup<T> component;
+    private By staticLocator;
+    private String componentData;
+    private String componentInitialData;
+    private String componentExpectedData;
+    protected RadioButtonGroup.Selection selection;
+
+    protected RadioButtons() {
+        super();
+    }
+
+    protected RadioButtons(WebElement element) {
+        super(element);
+    }
+
+    protected By getStaticLocator() {
+        if (staticLocator == null) {
+            staticLocator = LocatorUtils.processForSubstitutions(getLocator(), getSubstitutions());
+        }
+
+        return staticLocator;
+    }
+
+    protected Map<String, String> getSubstitutions() {
+        if (substitutions == null) {
+            substitutions = new HashMap<>();
+        }
+
+        return substitutions;
+    }
+
+    public RadioButtons<T> withSubstitutions(Map<String, String> substitutions) {
+        this.substitutions = substitutions;
+        getComponent().setSubstitutions(substitutions);
+        return this;
+    }
+
+    protected RadioButtonGroup.Selection getSelection() {
+        return selection == null ? RadioButtonGroup.Selection.EQUALS : selection;
+    }
+
+    public RadioButtons<T> withSelection(RadioButtonGroup.Selection selection) {
+        this.selection = selection;
+        return this;
+    }
+
+    @Override
+    protected void init() {
+        component = new RadioButtonGroup<>(getCoreElement());
+        component.setClazz(getClazz());
+        component.setSelection(getSelection());
+        component.setSubstitutions(getSubstitutions());
+        initComponentDataVariables();
+        component.initializeData(componentData, componentInitialData, componentExpectedData);
+        LocatorUtils.setLocator(component, getStaticLocator());
+    }
+
+    @Override
+    public void initializeData(String data, String initialData, String expectedData) {
+        componentData = data;
+        componentInitialData = initialData;
+        componentExpectedData = expectedData;
+        if (component != null) {
+            component.initializeData(componentData, componentInitialData, componentExpectedData);
+        }
+
+        super.initializeData(data, initialData, expectedData);
+    }
+
+    /**
+     * For performance reasons, only initialize the data once
+     */
+    private void initComponentDataVariables() {
+        if (componentData == null) {
+            componentData = getData(DataTypes.Data);
+        }
+
+        if (componentInitialData == null) {
+            componentInitialData = getData(DataTypes.Initial);
+        }
+
+        if (componentExpectedData == null) {
+            componentExpectedData = getData(DataTypes.Expected);
+        }
+    }
+
+    /**
+     * Get the component if it is necessary to implement custom logic for setting/getting the value
+     *
+     * @return RadioButtonGroup&lt;T&gt;
+     */
+    protected RadioButtonGroup<T> getComponent() {
+        return component;
+    }
+
+    @Override
+    public void setValue() {
+        getComponent().setValue();
+    }
+
+    @Override
+    public String getValue() {
+        return getComponent().getValue();
+    }
+
+    @Override
+    public void validateData(DataTypes validationMethod) {
+        getComponent().validateData(validationMethod);
+    }
+
+    public List<T> getAllOptions() {
+        return getComponent().getAllOptions();
+    }
+
+    /**
+     * Get the Radio Button Group class type which is used create the instances of the available options
+     *
+     * @return Class<T>
+     */
+    protected abstract Class<T> getClazz();
+}


### PR DESCRIPTION
The logic in PrimeFacesRadioButtonGroup.java is mainly generic and would apply to other application specific radio buttons in general.  So, this logic was moved into a separate abstract class to reduce duplicate code in these cases.

The private methods in RadioButtonGroup.java were made protected such that the class could be extended should custom logic be necessary and these methods could be reused.