### PR TITLE
Fix cannot set validations for checkboxes due to site changes

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/RoboFormLoginPage.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/RoboFormLoginPage.java
@@ -1,14 +1,10 @@
 package com.automation.common.ui.app.pageObjects;
 
-import com.automation.common.ui.app.components.CheckBoxAJAX;
-import com.automation.common.ui.app.components.CheckBoxBasic;
-import com.automation.common.ui.app.components.CheckBoxLabel;
 import com.automation.common.ui.app.components.TextBox;
 import com.taf.automation.ui.support.PageObjectV2;
 import com.taf.automation.ui.support.TestContext;
 import com.taf.automation.ui.support.util.AssertJUtil;
 import com.taf.automation.ui.support.util.JsUtils;
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import ru.yandex.qatools.allure.annotations.Step;
@@ -18,22 +14,11 @@ import static com.taf.automation.ui.support.util.AssertsUtil.componentCannotBeSe
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class RoboFormLoginPage extends PageObjectV2 {
-    private static final String VALUE_TO_BE_SET = "false";
-
     @FindBy(id = "username")
     private TextBox emailOrUserId;
 
     @FindBy(id = "password")
     private TextBox password;
-
-    @FindBy(id = "safe_device")
-    private CheckBoxAJAX rememberAJAX;
-
-    @FindBy(xpath = "//*[@id='safe_device']/..")
-    private CheckBoxLabel rememberLabel;
-
-    @FindBy(id = "safe_device")
-    private CheckBoxBasic rememberBasic;
 
     public RoboFormLoginPage() {
         super();
@@ -47,9 +32,6 @@ public class RoboFormLoginPage extends PageObjectV2 {
     public void disableFieldsAndValidateCannotSet() {
         disableFieldAndValidateEmailOrUserId();
         disableFieldAndValidatePassword();
-        disableFieldAndValidateRememberLabel();
-        disableFieldAndValidateRememberAJAX();
-        disableFieldAndValidateRememberBasic();
     }
 
     private void disableField(PageComponent component) {
@@ -58,11 +40,6 @@ public class RoboFormLoginPage extends PageObjectV2 {
 
     private void disableField(WebElement element) {
         JsUtils.addAttribute(element, "disabled", "");
-    }
-
-    private void makeCheckBoxVisible(By locator) {
-        WebElement element = getDriver().findElement(locator);
-        JsUtils.execute(getDriver(), "arguments[0].style.opacity = 1;", element);
     }
 
     @Step("Disable And Validate:  Email Or User Id")
@@ -77,35 +54,10 @@ public class RoboFormLoginPage extends PageObjectV2 {
         assertThat("Password", password, componentCannotBeSetFast("67890"));
     }
 
-    @Step("Disable And Validate:  Remember (Label)")
-    private void disableFieldAndValidateRememberLabel() {
-        disableField(rememberLabel.getInput());
-        assertThat("Remember (Label)", rememberLabel, componentCannotBeSetFast(VALUE_TO_BE_SET));
-    }
-
-    @Step("Disable And Validate:  Remember (AJAX)")
-    private void disableFieldAndValidateRememberAJAX() {
-        // On this page the element is considered hidden, it is necessary to make it displayed for the test
-        makeCheckBoxVisible(rememberAJAX.getLocator());
-        disableField(rememberAJAX);
-        assertThat("Remember (AJAX)", rememberAJAX, componentCannotBeSetFast(VALUE_TO_BE_SET));
-    }
-
-    @Step("Disable And Validate:  Remember (Basic)")
-    private void disableFieldAndValidateRememberBasic() {
-        // On this page the element is considered hidden, it is necessary to make it displayed for the test
-        makeCheckBoxVisible(rememberBasic.getLocator());
-        disableField(rememberBasic);
-        assertThat("Remember (Basic)", rememberBasic, componentCannotBeSetFast(VALUE_TO_BE_SET));
-    }
-
     @Step("Disable Fields And Validate Cannot Set using AssertJ")
     public void disableFieldsAndValidateCannotSetAssertJ() {
         disableFieldAndValidateEmailOrUserIdAssertJ();
         disableFieldAndValidatePasswordAssertJ();
-        disableFieldAndValidateRememberLabelAssertJ();
-        disableFieldAndValidateRememberAJAXAssertJ();
-        disableFieldAndValidateRememberBasicAssertJ();
     }
 
     @Step("Disable And Validate:  Email Or User Id using AssertJ")
@@ -118,28 +70,6 @@ public class RoboFormLoginPage extends PageObjectV2 {
     private void disableFieldAndValidatePasswordAssertJ() {
         disableField(password);
         AssertJUtil.assertThat(password).as("Password").cannotBeSetFast("67890");
-    }
-
-    @Step("Disable And Validate:  Remember (Label) using AssertJ")
-    private void disableFieldAndValidateRememberLabelAssertJ() {
-        disableField(rememberLabel.getInput());
-        AssertJUtil.assertThat(rememberLabel).as("Remember (Label)").cannotBeSetFast(VALUE_TO_BE_SET);
-    }
-
-    @Step("Disable And Validate:  Remember (AJAX) using AssertJ")
-    private void disableFieldAndValidateRememberAJAXAssertJ() {
-        // On this page the element is considered hidden, it is necessary to make it displayed for the test
-        makeCheckBoxVisible(rememberAJAX.getLocator());
-        disableField(rememberAJAX);
-        AssertJUtil.assertThat(rememberAJAX).as("Remember (AJAX)").cannotBeSetFast(VALUE_TO_BE_SET);
-    }
-
-    @Step("Disable And Validate:  Remember (Basic) using AssertJ")
-    private void disableFieldAndValidateRememberBasicAssertJ() {
-        // On this page the element is considered hidden, it is necessary to make it displayed for the test
-        makeCheckBoxVisible(rememberBasic.getLocator());
-        disableField(rememberBasic);
-        AssertJUtil.assertThat(rememberBasic).as("Remember (Basic)").cannotBeSetFast(VALUE_TO_BE_SET);
     }
 
 }

--- a/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/SeleniumEasyCheckBoxDemoPage.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/SeleniumEasyCheckBoxDemoPage.java
@@ -1,12 +1,23 @@
 package com.automation.common.ui.app.pageObjects;
 
+import com.automation.common.ui.app.components.CheckBoxAJAX;
+import com.automation.common.ui.app.components.CheckBoxBasic;
 import com.automation.common.ui.app.components.CheckBoxLabel;
 import com.taf.automation.ui.support.PageObjectV2;
 import com.taf.automation.ui.support.TestContext;
+import com.taf.automation.ui.support.util.AssertJUtil;
+import com.taf.automation.ui.support.util.JsUtils;
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import ru.yandex.qatools.allure.annotations.Step;
+import ui.auto.core.pagecomponent.PageComponent;
+
+import static com.taf.automation.ui.support.util.AssertsUtil.componentCannotBeSetFast;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SeleniumEasyCheckBoxDemoPage extends PageObjectV2 {
+    private static final String VALUE_TO_BE_SET = "true";
+
     @FindBy(xpath = "//*[text()='Option 1']/..")
     private CheckBoxLabel option1;
 
@@ -18,6 +29,12 @@ public class SeleniumEasyCheckBoxDemoPage extends PageObjectV2 {
 
     @FindBy(xpath = "//*[text()='Option 4']/..")
     private CheckBoxLabel option4;
+
+    @FindBy(xpath = "//*[text()='Option 1']/input")
+    private CheckBoxAJAX option1asAJAX;
+
+    @FindBy(xpath = "//*[text()='Option 1']/input")
+    private CheckBoxBasic option1asBasic;
 
     public SeleniumEasyCheckBoxDemoPage() {
         super();
@@ -53,6 +70,64 @@ public class SeleniumEasyCheckBoxDemoPage extends PageObjectV2 {
         selectOption2();
         selectOption3();
         selectOption4();
+    }
+
+    private void disableField(PageComponent component) {
+        disableField(component.getCoreElement());
+    }
+
+    private void disableField(WebElement element) {
+        JsUtils.addAttribute(element, "disabled", "");
+    }
+
+    @Step("Disable Fields And Validate Cannot Set")
+    public void disableFieldsAndValidateCannotSet() {
+        disableFieldAndValidateOption1Label();
+        disableFieldAndValidateOption1AJAX();
+        disableFieldAndValidateOption1Basic();
+    }
+
+    @Step("Disable And Validate:  option1 (Label)")
+    private void disableFieldAndValidateOption1Label() {
+        disableField(option1.getInput());
+        assertThat("option1 (Label)", option1, componentCannotBeSetFast(VALUE_TO_BE_SET));
+    }
+
+    @Step("Disable And Validate:  option1 (AJAX)")
+    private void disableFieldAndValidateOption1AJAX() {
+        disableField(option1asAJAX);
+        assertThat("option1 (AJAX)", option1asAJAX, componentCannotBeSetFast(VALUE_TO_BE_SET));
+    }
+
+    @Step("Disable And Validate:  option1 (Basic)")
+    private void disableFieldAndValidateOption1Basic() {
+        disableField(option1asBasic);
+        assertThat("option1 (Basic)", option1asBasic, componentCannotBeSetFast(VALUE_TO_BE_SET));
+    }
+
+    @Step("Disable Fields And Validate Cannot Set using AssertJ")
+    public void disableFieldsAndValidateCannotSetAssertJ() {
+        disableFieldAndValidateOption1LabelAssertJ();
+        disableFieldAndValidateOption1AJAXAssertJ();
+        disableFieldAndValidateOption1BasicAssertJ();
+    }
+
+    @Step("Disable And Validate:  Option1 (Label) using AssertJ")
+    private void disableFieldAndValidateOption1LabelAssertJ() {
+        disableField(option1.getInput());
+        AssertJUtil.assertThat(option1).as("Option1 (Label)").cannotBeSetFast(VALUE_TO_BE_SET);
+    }
+
+    @Step("Disable And Validate:  Option1 (AJAX) using AssertJ")
+    private void disableFieldAndValidateOption1AJAXAssertJ() {
+        disableField(option1asAJAX);
+        AssertJUtil.assertThat(option1asAJAX).as("Option1 (AJAX)").cannotBeSetFast(VALUE_TO_BE_SET);
+    }
+
+    @Step("Disable And Validate:  Option1 (Basic) using AssertJ")
+    private void disableFieldAndValidateOption1BasicAssertJ() {
+        disableField(option1asBasic);
+        AssertJUtil.assertThat(option1asBasic).as("Option1 (Basic)").cannotBeSetFast(VALUE_TO_BE_SET);
     }
 
 }

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/AssertJTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/AssertJTest.java
@@ -6,6 +6,7 @@ import com.automation.common.ui.app.components.UnitTestWebElement;
 import com.automation.common.ui.app.pageObjects.FakeComponentsPage;
 import com.automation.common.ui.app.pageObjects.Navigation;
 import com.automation.common.ui.app.pageObjects.RoboFormLoginPage;
+import com.automation.common.ui.app.pageObjects.SeleniumEasyCheckBoxDemoPage;
 import com.taf.automation.asserts.AssertJCondition;
 import com.taf.automation.asserts.CustomSoftAssertions;
 import com.taf.automation.ui.support.Rand;
@@ -248,6 +249,10 @@ public class AssertJTest extends TestNGBase {
         new Navigation(getContext()).toRoboFormLogin(Utils.isCleanCookiesSupported());
         RoboFormLoginPage roboFormLoginPage = new RoboFormLoginPage(getContext());
         roboFormLoginPage.disableFieldsAndValidateCannotSetAssertJ();
+
+        new Navigation(getContext()).toSeleniumEasyBasicCheckbox(Utils.isCleanCookiesSupported());
+        SeleniumEasyCheckBoxDemoPage seleniumEasyCheckBoxDemoPage = new SeleniumEasyCheckBoxDemoPage(getContext());
+        seleniumEasyCheckBoxDemoPage.disableFieldsAndValidateCannotSetAssertJ();
     }
 
     @Features("AssertJUtil")

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/AssertsTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/AssertsTest.java
@@ -8,6 +8,7 @@ import com.automation.common.ui.app.components.UnitTestWebElement;
 import com.automation.common.ui.app.pageObjects.FakeComponentsPage;
 import com.automation.common.ui.app.pageObjects.Navigation;
 import com.automation.common.ui.app.pageObjects.RoboFormLoginPage;
+import com.automation.common.ui.app.pageObjects.SeleniumEasyCheckBoxDemoPage;
 import com.taf.automation.asserts.CustomSoftAssertions;
 import com.taf.automation.ui.support.AssertAggregator;
 import com.taf.automation.ui.support.testng.TestNGBase;
@@ -593,6 +594,10 @@ public class AssertsTest extends TestNGBase {
         new Navigation(getContext()).toRoboFormLogin(Utils.isCleanCookiesSupported());
         RoboFormLoginPage roboFormLoginPage = new RoboFormLoginPage(getContext());
         roboFormLoginPage.disableFieldsAndValidateCannotSet();
+
+        new Navigation(getContext()).toSeleniumEasyBasicCheckbox(Utils.isCleanCookiesSupported());
+        SeleniumEasyCheckBoxDemoPage seleniumEasyCheckBoxDemoPage = new SeleniumEasyCheckBoxDemoPage(getContext());
+        seleniumEasyCheckBoxDemoPage.disableFieldsAndValidateCannotSet();
     }
 
     @Features("SelectEnhanced")


### PR DESCRIPTION
The Robo Form Login Page has changed which is causing some failures.  I moved the validations to Selenium Easy CheckBox Demo Page to resolve the validation failures.