### PR TITLE
Add Edge Chromium support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <maven-assembly-plugin>3.3.0</maven-assembly-plugin>
         <guava.version>25.0-jre</guava.version>
         <selenium.version>3.141.59</selenium.version>
+        <selenium.edge.version>3.141.0</selenium.edge.version>
         <appium.version>7.3.0</appium.version>
         <ui.auto.core.version>2.5.15</ui.auto.core.version>
         <testNg.version>6.14.3</testNg.version>

--- a/taf/pom.xml
+++ b/taf/pom.xml
@@ -84,6 +84,11 @@
             <version>${selenium.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.microsoft.edge</groupId>
+            <artifactId>msedge-selenium-tools-java</artifactId>
+            <version>${selenium.edge.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.appium</groupId>
             <artifactId>java-client</artifactId>
             <version>${appium.version}</version>

--- a/taf/src/main/java/com/taf/automation/ui/support/TestProperties.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/TestProperties.java
@@ -259,6 +259,9 @@ public class TestProperties {
     @Property("webdriver.screenshot.view.port.only")
     private boolean viewPortOnly = true;
 
+    @Property("edge.legacy.install")
+    private boolean edgeLegacyInstall;
+
     // May need edit configuration for the working directory when running from IDE.
     // Use same working directory as RunTests.
     @Property("source.js")
@@ -860,6 +863,10 @@ public class TestProperties {
 
     public boolean isViewPortOnly() {
         return viewPortOnly;
+    }
+
+    public boolean isEdgeLegacyInstall() {
+        return edgeLegacyInstall;
     }
 
     /**

--- a/taf/src/main/java/com/taf/automation/ui/support/WebDriverTypeEnum.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/WebDriverTypeEnum.java
@@ -12,8 +12,6 @@ import org.openqa.selenium.UnexpectedAlertBehaviour;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.edge.EdgeDriver;
-import org.openqa.selenium.edge.EdgeOptions;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxDriverLogLevel;
 import org.openqa.selenium.firefox.FirefoxOptions;
@@ -33,7 +31,8 @@ import java.net.URL;
 
 public enum WebDriverTypeEnum {
     CHROME(BrowserType.CHROME, ChromeDriver.class),
-    EDGE(BrowserType.EDGE, EdgeDriver.class),
+    EDGE_LEGACY(BrowserType.EDGE, org.openqa.selenium.edge.EdgeDriver.class),
+    EDGE(BrowserType.EDGE, com.microsoft.edge.seleniumtools.EdgeDriver.class),
     FIREFOX(BrowserType.FIREFOX, FirefoxDriver.class),
     IE(BrowserType.IE, InternetExplorerDriver.class),
     OPERA_BLINK(BrowserType.OPERA_BLINK, OperaDriver.class),
@@ -127,8 +126,10 @@ public enum WebDriverTypeEnum {
                 return getChromeDriver(prop, capabilities);
             case SAFARI:
                 return getSafariDriver(prop, capabilities);
+            case EDGE_LEGACY:
+                return getEdgeLegacyDriver(prop, capabilities);
             case EDGE:
-                return getEdgeDriver(prop, capabilities);
+                return getEdgeChromiumDriver(prop, capabilities);
             case ANDROID:
                 return getAndroidDriver(prop, capabilities);
             case IPAD:
@@ -161,6 +162,8 @@ public enum WebDriverTypeEnum {
             capabilities.setCapability(FirefoxOptions.FIREFOX_OPTIONS, getFirefoxOptions(prop, mergeCapabilities, false));
         } else if (prop.getBrowserType() == CHROME) {
             capabilities.setCapability(ChromeOptions.CAPABILITY, getChromeOptions(prop, mergeCapabilities));
+        } else if (prop.getBrowserType() == EDGE) {
+            capabilities.setCapability(com.microsoft.edge.seleniumtools.EdgeOptions.CAPABILITY, getEdgeChromiumOptions(prop, mergeCapabilities));
         } else if (prop.getBrowserType() == SAFARI) {
             capabilities.setCapability(SafariOptions.CAPABILITY, getSafariOptions(prop, mergeCapabilities));
         } else {
@@ -251,15 +254,35 @@ public enum WebDriverTypeEnum {
         return options;
     }
 
-    private EdgeDriver getEdgeDriver(TestProperties prop, DesiredCapabilities mergeCapabilities) {
-        EdgeOptions options = getEdgeOptions(prop, mergeCapabilities);
-        return new EdgeDriver(options);
+    private org.openqa.selenium.edge.EdgeDriver getEdgeLegacyDriver(TestProperties prop, DesiredCapabilities mergeCapabilities) {
+        org.openqa.selenium.edge.EdgeOptions options = getEdgeLegacyOptions(prop, mergeCapabilities);
+        return new org.openqa.selenium.edge.EdgeDriver(options);
     }
 
     @SuppressWarnings("squid:S1172")
-    private EdgeOptions getEdgeOptions(TestProperties prop, DesiredCapabilities mergeCapabilities) {
-        EdgeOptions options = new EdgeOptions();
+    private org.openqa.selenium.edge.EdgeOptions getEdgeLegacyOptions(TestProperties prop, DesiredCapabilities mergeCapabilities) {
+        org.openqa.selenium.edge.EdgeOptions options = new org.openqa.selenium.edge.EdgeOptions();
         options.merge(mergeCapabilities);
+        return options;
+    }
+
+    private com.microsoft.edge.seleniumtools.EdgeDriver getEdgeChromiumDriver(TestProperties prop, DesiredCapabilities mergeCapabilities) {
+        com.microsoft.edge.seleniumtools.EdgeOptions options = getEdgeChromiumOptions(prop, mergeCapabilities);
+        return new com.microsoft.edge.seleniumtools.EdgeDriver(options);
+    }
+
+    private com.microsoft.edge.seleniumtools.EdgeOptions getEdgeChromiumOptions(TestProperties prop, DesiredCapabilities mergeCapabilities) {
+        com.microsoft.edge.seleniumtools.EdgeOptions options = new com.microsoft.edge.seleniumtools.EdgeOptions();
+        options.addArguments("--ignore-certificate-errors");
+        options.addArguments("--disable-gpu");
+        options.addArguments("--dns-prefetch-disable");
+
+        if (prop.getUserAgent() != null) {
+            options.addArguments("user-agent=" + prop.getUserAgent());
+        }
+
+        options.merge(mergeCapabilities);
+        options.setUnhandledPromptBehaviour(UnexpectedAlertBehaviour.IGNORE);
         return options;
     }
 

--- a/taf/src/main/java/com/taf/automation/ui/support/testng/TestNGBaseWithoutListeners.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/testng/TestNGBaseWithoutListeners.java
@@ -146,7 +146,13 @@ public class TestNGBaseWithoutListeners {
             installDriver("chromedriver", "webdriver.chrome.driver");
             if (System.getProperty("os.name").toUpperCase().startsWith("WINDOWS")) {
                 installDriver("IEDriverServer", "webdriver.ie.driver");
-                installDriver("MicrosoftWebDriver", "webdriver.edge.driver");
+
+                // Edge (Legacy/Original) & Edge (Chromium) use the same system property for the executable
+                // as such we can only install 1 locally.  The user must decide which Edge will be used.
+                // Microsoft has removed Edge (Legacy/Original) in the normal windows 10 installations but in corporate
+                // environments it is still available for now to allow companies to decide when to remove.
+                String edgeDriverName = props.isEdgeLegacyInstall() ? "MicrosoftWebDriver" : "msedgedriver";
+                installDriver(edgeDriverName, "webdriver.edge.driver");
             }
 
             if (props.getFirefoxBin() != null) {

--- a/taf/src/main/java/com/taf/automation/ui/support/util/Utils.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/util/Utils.java
@@ -1051,7 +1051,11 @@ public class Utils {
     public static boolean isCleanCookiesSupported() {
         WebDriverTypeEnum browser = TestProperties.getInstance().getBrowserType();
 
-        if (browser == WebDriverTypeEnum.FIREFOX || browser == WebDriverTypeEnum.CHROME) {
+        if (browser == WebDriverTypeEnum.FIREFOX
+                || browser == WebDriverTypeEnum.CHROME
+                || browser == WebDriverTypeEnum.EDGE_LEGACY
+                || browser == WebDriverTypeEnum.EDGE
+        ) {
             return true;
         }
 

--- a/taf/src/main/resources/webdrivers/linux/msedgedriver
+++ b/taf/src/main/resources/webdrivers/linux/msedgedriver
@@ -1,0 +1,1 @@
+Fake file needs to replaced with actual driver for Microsoft Edge (Chromium)

--- a/taf/src/main/resources/webdrivers/mac/msedgedriver
+++ b/taf/src/main/resources/webdrivers/mac/msedgedriver
@@ -1,0 +1,1 @@
+Fake file needs to replaced with actual driver for Microsoft Edge (Chromium)

--- a/taf/src/main/resources/webdrivers/win32/msedgedriver.exe
+++ b/taf/src/main/resources/webdrivers/win32/msedgedriver.exe
@@ -1,0 +1,1 @@
+Fake file needs to replaced with actual driver for Microsoft Edge (Chromium)

--- a/taf/src/main/resources/webdrivers/win64/msedgedriver.exe
+++ b/taf/src/main/resources/webdrivers/win64/msedgedriver.exe
@@ -1,0 +1,1 @@
+Fake file needs to replaced with actual driver for Microsoft Edge (Chromium)


### PR DESCRIPTION
For Selenium 3, Edge (Chromium) needs another dependency.  However, it is unclear what will happen in Selenium 4.  So, for now the fully qualified name was used for both Edge Legacy & Edge Chromium.  Since, it may be desirable to test Edge Legacy in the future even after support for it is dropped by Microsoft (provided you have a machine or a Selenium Grid with it) the enumeration will remain available.

Locally, it is not possible to run both Edge Legacy & Edge Chromium together in a test.  The issue is they share the same system property.  However, if using a Selenium Grid, then this should not be an issue.

Since, Edge Chromium is very close to Chrome the options for Chrome were used.