### PR TITLE
JavaScript to get all attributes on an element

### DIFF
--- a/taf/src/main/java/com/taf/automation/ui/support/util/JsUtils.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/util/JsUtils.java
@@ -1,5 +1,7 @@
 package com.taf.automation.ui.support.util;
 
+import com.google.gson.reflect.TypeToken;
+import com.taf.automation.api.JsonUtils;
 import com.taf.automation.ui.support.TestProperties;
 import com.taf.automation.ui.support.events.Event;
 import com.taf.automation.ui.support.events.EventType;
@@ -17,6 +19,9 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.lang.reflect.Type;
+import java.util.Map;
 
 /**
  * This class provides utility methods to work with JavaScript
@@ -38,6 +43,7 @@ public class JsUtils {
     private static final String ADD_ELEMENT_TO_PARENT = Utils.readResource("JS/AddElementToParent.js");
     private static final String REMOVE_ELEMENT = Utils.readResource("JS/RemoveElement.js");
     private static final String WAIT_FOR_XHR = Utils.readResource("JS/WaitForXHR.js");
+    private static final String GET_ALL_ATTRIBUTES = Utils.readResource("JS/GetAllAttributes.js");
 
     private JsUtils() {
         // Prevent initialization of class as all public methods should be static
@@ -543,6 +549,18 @@ public class JsUtils {
         WebElement element = getWebDriver().findElement(By.cssSelector("body"));
         String ajaxCounter = element.getAttribute("ajaxcounter");
         AssertJUtil.assertThat(NumberUtils.toInt(ajaxCounter, -1)).as("AJAX Counter").isEqualTo(0);
+    }
+
+    /**
+     * Get all attributes on the element
+     *
+     * @param element - Element to get all attributes
+     * @return all attributes (name, value) on the element
+     */
+    public static Map<String, String> getAllAttributes(WebElement element) {
+        String json = (String) execute(getWebDriver(), GET_ALL_ATTRIBUTES, element);
+        Type type = new TypeToken<Map<String, String>>() { }.getType();
+        return JsonUtils.getGson().fromJson(json, type);
     }
 
 }

--- a/taf/src/main/resources/JS/GetAllAttributes.js
+++ b/taf/src/main/resources/JS/GetAllAttributes.js
@@ -1,0 +1,8 @@
+var allAttributes = new Map();
+
+var attributes = arguments[0].attributes;
+for (let attr in attributes) {
+    allAttributes.set(attributes[attr].name, attributes[attr].value);
+}
+
+return JSON.stringify(Object.fromEntries(allAttributes));


### PR DESCRIPTION
Selenium does not provide a method to get all attributes on a method to get an attribute if you know the exact name.  This can be problematic if they are random or non-static.  If there are attributes with non-static names, then you can use this method to get all the attributes (and corresponding values) to find the attribute(s) you want.

**Note**:  There is a bug with Selenium that it cannot return a map from JavaScript.  So, it was necessary to do some workarounds to return a JSON string which we could manually convert to a map.