### PR TITLE
Add basic example to use MutationObserver from JavaScript

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/SeleniumEasyCheckBoxDemoPage.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/SeleniumEasyCheckBoxDemoPage.java
@@ -3,20 +3,29 @@ package com.automation.common.ui.app.pageObjects;
 import com.automation.common.ui.app.components.CheckBoxAJAX;
 import com.automation.common.ui.app.components.CheckBoxBasic;
 import com.automation.common.ui.app.components.CheckBoxLabel;
+import com.taf.automation.ui.support.BasicClock;
 import com.taf.automation.ui.support.PageObjectV2;
 import com.taf.automation.ui.support.TestContext;
+import com.taf.automation.ui.support.TestProperties;
 import com.taf.automation.ui.support.util.AssertJUtil;
 import com.taf.automation.ui.support.util.JsUtils;
+import com.taf.automation.ui.support.util.MutationObserverData;
+import com.taf.automation.ui.support.util.Utils;
+import net.jodah.failsafe.Failsafe;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import ru.yandex.qatools.allure.annotations.Step;
 import ui.auto.core.pagecomponent.PageComponent;
 
+import java.util.concurrent.TimeUnit;
+
 import static com.taf.automation.ui.support.util.AssertsUtil.componentCannotBeSetFast;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@SuppressWarnings("java:S3252")
 public class SeleniumEasyCheckBoxDemoPage extends PageObjectV2 {
     private static final String VALUE_TO_BE_SET = "true";
+    private static final BasicClock clock = new BasicClock();
 
     @FindBy(xpath = "//*[text()='Option 1']/..")
     private CheckBoxLabel option1;
@@ -80,6 +89,14 @@ public class SeleniumEasyCheckBoxDemoPage extends PageObjectV2 {
         JsUtils.addAttribute(element, "disabled", "");
     }
 
+    private void enableField(PageComponent component) {
+        enableField(component.getCoreElement());
+    }
+
+    private void enableField(WebElement element) {
+        JsUtils.execute(getDriver(), "arguments[0].removeAttribute('disabled');", element);
+    }
+
     @Step("Disable Fields And Validate Cannot Set")
     public void disableFieldsAndValidateCannotSet() {
         disableFieldAndValidateOption1Label();
@@ -128,6 +145,51 @@ public class SeleniumEasyCheckBoxDemoPage extends PageObjectV2 {
     private void disableFieldAndValidateOption1BasicAssertJ() {
         disableField(option1asBasic);
         AssertJUtil.assertThat(option1asBasic).as("Option1 (Basic)").cannotBeSetFast(VALUE_TO_BE_SET);
+    }
+
+    @Step("Attach Mutation Observer To Option1")
+    public void attachMutationObserverToOption1() {
+        JsUtils.attachMutationObserverAddRemoveAttribute(option1.getCoreElement());
+    }
+
+
+    @Step("Wait For Disable & Enable of Option1")
+    public void waitForDisableEnableOption1() {
+        // We will wait until negative timeout before triggering the disable & enable on option 1 to
+        // simulate what would normally occur in an application in which this would be needed
+        long triggerTime = clock.laterBy(TimeUnit.SECONDS.toMillis(TestProperties.getInstance().getNegativeTimeout()));
+        Failsafe.with(Utils.getPollingRetryPolicy())
+                .run(() -> validateDisableEnableOption1(triggerTime));
+    }
+
+    private void validateDisableEnableOption1(long triggerTime) {
+        // We will wait until the specified time to simulate an application doing sometime that we need to
+        // wait for completion before continuing.  This would not be in normal code on the assertion after it
+        if (!clock.isNowBefore(triggerTime)) {
+            performDisableEnableOption1();
+        }
+
+        // Check if the application has completed doing the action
+        AssertJUtil.assertThat(wasDisableEnableOption1()).as("Option1 did not become disabled & enabled").isTrue();
+    }
+
+    private boolean wasDisableEnableOption1() {
+        // Get the current data from the DOM and check if the application has completed the action.
+        // In this case, we are waiting for any attribute to added & any attribute to be remove in any order.
+        // In a real application, you would observe the data that would indicate completion.
+        MutationObserverData mutationObserverData = JsUtils.getMutationObserverData();
+        return mutationObserverData.isAttributeAdded() && mutationObserverData.isAttributeRemoved();
+    }
+
+    @Step("Perform Disable & Enable of Option1")
+    private void performDisableEnableOption1() {
+        // This simulates adding an attribute.
+        // A real application might add an attribute to indicate it is processing.
+        disableField(option1);
+
+        // This simulates removing an attribute.
+        // A real application might remove an attribute to indicate that it is complete.
+        enableField(option1);
     }
 
 }

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/BasicMutationObserverTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/BasicMutationObserverTest.java
@@ -1,0 +1,28 @@
+package com.automation.common.ui.app.tests;
+
+import com.automation.common.ui.app.pageObjects.Navigation;
+import com.automation.common.ui.app.pageObjects.SeleniumEasyCheckBoxDemoPage;
+import com.taf.automation.ui.support.testng.TestNGBase;
+import com.taf.automation.ui.support.util.DomainObjectUtils;
+import com.taf.automation.ui.support.util.Utils;
+import org.testng.ITestContext;
+import org.testng.annotations.Test;
+import ru.yandex.qatools.allure.annotations.Features;
+import ru.yandex.qatools.allure.annotations.Severity;
+import ru.yandex.qatools.allure.annotations.Stories;
+import ru.yandex.qatools.allure.model.SeverityLevel;
+
+public class BasicMutationObserverTest extends TestNGBase {
+    @Features("JsUtils")
+    @Stories("Validate basic usage of MutationObserver")
+    @Severity(SeverityLevel.TRIVIAL)
+    @Test
+    public void testMutationObserver(ITestContext injectedContext) {
+        DomainObjectUtils.overwriteTestName(injectedContext);
+        new Navigation(getContext()).toSeleniumEasyBasicCheckbox(Utils.isCleanCookiesSupported());
+        SeleniumEasyCheckBoxDemoPage seleniumEasyCheckBoxDemoPage = new SeleniumEasyCheckBoxDemoPage(getContext());
+        seleniumEasyCheckBoxDemoPage.attachMutationObserverToOption1();
+        seleniumEasyCheckBoxDemoPage.waitForDisableEnableOption1();
+    }
+
+}

--- a/automation-tests/src/main/resources/suites/FrameworkSmokeTestSuite.xml
+++ b/automation-tests/src/main/resources/suites/FrameworkSmokeTestSuite.xml
@@ -406,6 +406,12 @@
         </classes>
     </test>
 
+    <test name="Basic MutationObserver Test">
+        <classes>
+            <class name="com.automation.common.ui.app.tests.BasicMutationObserverTest"/>
+        </classes>
+    </test>
+
     <test name="Page Object Utils Test">
         <parameter name="base-data-set" value="data/ui/RoboFormDynamic_TestData.xml"/>
         <parameter name="add-data-useDynamicPage" value="false"/>

--- a/taf/src/main/java/com/taf/automation/ui/support/util/JsUtils.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/util/JsUtils.java
@@ -44,6 +44,9 @@ public class JsUtils {
     private static final String REMOVE_ELEMENT = Utils.readResource("JS/RemoveElement.js");
     private static final String WAIT_FOR_XHR = Utils.readResource("JS/WaitForXHR.js");
     private static final String GET_ALL_ATTRIBUTES = Utils.readResource("JS/GetAllAttributes.js");
+    private static final String MUTATION_OBSERVER_ADD_REMOVE_ATTRIBUTES = Utils.readResource("JS/MutationObserverAddRemoveAttributes.js");
+    private static final String MUTATION_OBSERVER_DISCONNECT = Utils.readResource("JS/MutationObserverDisconnect.js");
+    private static final String MUTATION_OBSERVER_GET_DATA = Utils.readResource("JS/MutationObserverGetData.js");
 
     private JsUtils() {
         // Prevent initialization of class as all public methods should be static
@@ -561,6 +564,32 @@ public class JsUtils {
         String json = (String) execute(getWebDriver(), GET_ALL_ATTRIBUTES, element);
         Type type = new TypeToken<Map<String, String>>() { }.getType();
         return JsonUtils.getGson().fromJson(json, type);
+    }
+
+    /**
+     * Attach MutationObserver for Add/Remove Attribute
+     *
+     * @param element - Element to attach the MutationObserver for Add/Remove Attribute to
+     */
+    public static void attachMutationObserverAddRemoveAttribute(WebElement element) {
+        execute(getWebDriver(), MUTATION_OBSERVER_ADD_REMOVE_ATTRIBUTES, element);
+    }
+
+    /**
+     * Disconnect MutationObserver
+     */
+    public static void disconnectMutationObserver() {
+        execute(getWebDriver(), MUTATION_OBSERVER_DISCONNECT, (Object[]) null);
+    }
+
+    /**
+     * Get the current MutationObserverData
+     *
+     * @return current MutationObserverData
+     */
+    public static MutationObserverData getMutationObserverData() {
+        String json = (String) execute(getWebDriver(), MUTATION_OBSERVER_GET_DATA, (Object[]) null);
+        return JsonUtils.getGson().fromJson(json, MutationObserverData.class);
     }
 
 }

--- a/taf/src/main/java/com/taf/automation/ui/support/util/MutationObserverData.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/util/MutationObserverData.java
@@ -1,0 +1,26 @@
+package com.taf.automation.ui.support.util;
+
+/**
+ * Class to hold the data from MutationObserver
+ */
+public class MutationObserverData {
+    private boolean attributeAdded;
+    private boolean attributeRemoved;
+
+    public boolean isAttributeAdded() {
+        return attributeAdded;
+    }
+
+    public void setAttributeAdded(boolean attributeAdded) {
+        this.attributeAdded = attributeAdded;
+    }
+
+    public boolean isAttributeRemoved() {
+        return attributeRemoved;
+    }
+
+    public void setAttributeRemoved(boolean attributeRemoved) {
+        this.attributeRemoved = attributeRemoved;
+    }
+
+}

--- a/taf/src/main/resources/JS/MutationObserverAddRemoveAttributes.js
+++ b/taf/src/main/resources/JS/MutationObserverAddRemoveAttributes.js
@@ -1,0 +1,34 @@
+//
+// Attach MutationObserver to the specified element.
+// Note:  Any previous MutationObserver added by automation should be disconnected
+// as the variable used to store it will be overridden.
+//
+var element = arguments[0];
+
+window.automation_last_attribute_value = null;
+window.automation_attribute_added = false;
+window.automation_attribute_removed = false;
+
+window.automation_observer = new MutationObserver(function(mutations) {
+    mutations.forEach(function(mutation) {
+    if (mutation.type == "attributes") {
+        let current_attribute_exists = mutation.target.attributes[mutation.attributeName] !== undefined;
+        let current_attribute_removed = !current_attribute_exists && mutation.oldValue !== null;
+        if (current_attribute_removed) {
+            window.automation_attribute_removed = true;
+        }
+
+        if (!current_attribute_removed
+            && current_attribute_exists
+            && mutation.oldValue === null
+            && window.automation_last_attribute_value === null
+        ) {
+            window.automation_attribute_added = true;
+        }
+
+        window.automation_last_attribute_value = current_attribute_exists ? true : null;
+    }
+  });
+});
+
+window.automation_observer.observe(element, {attributes: true, attributeOldValue: true});

--- a/taf/src/main/resources/JS/MutationObserverDisconnect.js
+++ b/taf/src/main/resources/JS/MutationObserverDisconnect.js
@@ -1,0 +1,2 @@
+// The automation_observer must have been added before
+window.automation_observer.disconnect();

--- a/taf/src/main/resources/JS/MutationObserverGetData.js
+++ b/taf/src/main/resources/JS/MutationObserverGetData.js
@@ -1,0 +1,6 @@
+var data = new Object();
+
+data.attributeAdded = window.automation_attribute_added;
+data.attributeRemoved = window.automation_attribute_removed;
+
+return JSON.stringify(data);


### PR DESCRIPTION
When Selenium does not provide a way to directly determine some action you need to wait for complete is done, then it may be necessary to use the MutationObserver from JavaScript.  This class allows you to find out anything that changed on an element.  It may take some research to determine what indicates that your application has completed the action.  However, the alternative of using sleeps just slows down your automation and it should be avoided.

I have written some JavaScript to be able to handle the simple case in which any attribute is added (to indicate processing) and any attribute is removed (to indicate completion) using the MutationObserver class.  You probably could handle this case using the ExpectedConditions class provided the attribute is known and not dynamic.  However, if you have a more complicated scenario, then this simple case can give you a place to start to find a solution to a more complicated case.

We need to store the information we care about in global variables to be access after Selenium executes the JavaScript.  So, I have used window to store the variables as it is global.  Additionally, the naming convention I am using is to indicate automation created the variable and to prevent collisions with JavaScript frameworks.

**Reference sites:**
- [MDN - MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver)
- [Getting To Know The MutationObserver API](https://www.smashingmagazine.com/2019/04/mutationobserver-api-guide/)
