### PR TITLE
Upgrade to TestNG 7.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <selenium.edge.version>3.141.0</selenium.edge.version>
         <appium.version>7.3.0</appium.version>
         <ui.auto.core.version>2.5.15</ui.auto.core.version>
-        <testNg.version>6.14.3</testNg.version>
+        <testNg.version>7.4.0</testNg.version>
         <hamcrest.version>1.3</hamcrest.version>
         <jetty-server.version>9.4.3.v20170317</jetty-server.version>
         <java.mail.version>1.4.1</java.mail.version>

--- a/taf/src/main/java/com/taf/automation/ui/support/testng/RetryListener.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/testng/RetryListener.java
@@ -1,23 +1,28 @@
 package com.taf.automation.ui.support.testng;
 
-import org.testng.IRetryAnalyzer;
+import com.taf.automation.ui.support.Lookup;
 import org.testng.ITestResult;
+import org.testng.util.RetryAnalyzerCount;
 
-public class RetryListener implements IRetryAnalyzer {
-    private int count = 0;
-    private int max;
+public class RetryListener extends RetryAnalyzerCount {
+    private static final String LOOKUP_KEY = "testng-retry-value";
 
-    public RetryListener(int times) {
-        max = times;
+    /**
+     * The number of retries is based on the lookup key from the Lookup class.  If the key is not found, then
+     * zero will be used which causes no retries to occur.
+     */
+    public RetryListener() {
+        setCount((int) Lookup.getInstance().getOrDefault(getLookupKey(), 0));
+    }
+
+    public static String getLookupKey() {
+        return LOOKUP_KEY;
     }
 
     @Override
-    public boolean retry(ITestResult iTestResult) {
-        if (count < max) {
-            count++;
-            return true;
-        }
-        return false;
+    public boolean retryMethod(ITestResult result) {
+        // No special logic retry is necessary just always retry
+        return true;
     }
 
 }

--- a/taf/src/main/java/com/taf/automation/ui/support/testng/TestParameterValidator.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/testng/TestParameterValidator.java
@@ -3,26 +3,29 @@ package com.taf.automation.ui.support.testng;
 import org.testng.IInvokedMethod;
 import org.testng.IInvokedMethodListener;
 import org.testng.ITestResult;
+import org.testng.TestNGException;
 import org.testng.annotations.Parameters;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
 public class TestParameterValidator implements IInvokedMethodListener {
-    private static final String MSG = "Parameter %s for method %s in class %s was not found in test suite file!";
-
     @SuppressWarnings("java:S112")
     @Override
     public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
         Method testMethod = method.getTestMethod().getConstructorOrMethod().getMethod();
         Annotation paramAnnotation = testMethod.getAnnotation(Parameters.class);
-        if (paramAnnotation != null && testResult.getTestContext() != null) {
+        if (paramAnnotation != null && testResult.getTestContext() != null && method.getTestMethod().isTest()) {
             String[] params = ((Parameters) paramAnnotation).value();
             for (String param : params) {
                 String value = testResult.getTestContext().getCurrentXmlTest().getParameter(param);
                 if (value == null) {
-                    String msg = String.format(MSG, param, testMethod.getName(), testMethod.getDeclaringClass().getName());
-                    throw new RuntimeException(msg);
+                    String xmlSuiteFileName = testResult.getTestContext().getSuite().getXmlSuite().getFileName();
+                    String xmlSuiteInfo = xmlSuiteFileName != null ? "in " + xmlSuiteFileName : "";
+                    throw new TestNGException("Parameter '" + param + "' is required by method " + testMethod.getName()
+                            + " in class " + testMethod.getDeclaringClass().getName()
+                            + " but has not been marked @Optional or defined\n"
+                            + xmlSuiteInfo);
                 }
             }
         }


### PR DESCRIPTION
Keys changes to TestNG 7.4.0 from 6.14.3:
- getRetryAnalyzer() has been removed instead it is necessary to use getRetryAnalyzer(ITestResult).  Along with this change, a default retry analyzer was introduced DisabledRetryAnalyzer which does not retry.
- setRetryAnalyzer has been removed instead it is necessary to use setRetryAnalyzerClass.  Due to this change, it does not seem possible to configure the retry analyzer instead it was necessary to create a workaround using the Lookup class.
- The TestParameterValidator is now being triggered on configuration methods.  It was necessary to only trigger the exception if a test which matches the previous version's behavior in the framework test suite.  Since, this had to be changed I made the message closer to TestNG's error when it occurs.