### PR TITLE
Add BigDecimal Converter

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/api/domainObjects/JsonIpDO.java
+++ b/automation-tests/src/main/java/com/automation/common/api/domainObjects/JsonIpDO.java
@@ -14,6 +14,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
 import org.apache.http.message.BasicStatusLine;
 import ru.yandex.qatools.allure.annotations.Step;
 
+import java.math.BigDecimal;
 import java.util.Map;
 
 /**
@@ -37,13 +38,18 @@ public class JsonIpDO extends ApiDomainObject {
     // Here you create an entity for the response
     private static class Response {
         // The Expected values to verify against
-        BasicStatusLine status;
-        String geoIP;
-        String apiHelp;
+        private BasicStatusLine status;
+        private String geoIP;
+        private String apiHelp;
+
+        /**
+         * Field used in testing the BigDecimalConverter
+         */
+        private BigDecimal pi;
 
         // Here is the actual response entity
         @XStreamOmitField
-        GenericHttpResponse<IP_Details> ip;
+        private GenericHttpResponse<IP_Details> ip;
 
         @Step("Validate Status")
         private void validateStatus() {
@@ -76,6 +82,9 @@ public class JsonIpDO extends ApiDomainObject {
             AssertJUtil.assertThat(actualIP).as("Invalid IP Address").matches("^[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}$");
             AssertJUtil.assertThat(actualGeoIp).as("GEO IP Incorrect").isEqualTo(geoIP);
             AssertJUtil.assertThat(actualApiHelp).as("API Help Incorrect").isEqualTo(apiHelp);
+
+            // BigDecimalConverter test
+            AssertJUtil.assertThat(pi).as("PI (to 11 decimal places)").isEqualByComparingTo("3.14159265359");
         }
     }
 

--- a/automation-tests/src/main/java/com/automation/common/ui/app/domainObjects/AddressProviderDO.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/domainObjects/AddressProviderDO.java
@@ -7,10 +7,17 @@ import com.taf.automation.ui.support.providers.AddressProvider;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import org.apache.commons.jexl3.JexlContext;
 
+import java.math.BigDecimal;
+
 @SuppressWarnings("squid:MaximumInheritanceDepth")
 @XStreamAlias("address-provider-do")
 public class AddressProviderDO extends DomainObject {
     private USAddress addressInfo;
+
+    /**
+     * Field used in testing the BigDecimalConverter
+     */
+    private BigDecimal pi;
 
     /**
      * The address count stored as a string.  Since we are using an alias to calculate this value,
@@ -42,6 +49,10 @@ public class AddressProviderDO extends DomainObject {
 
     public String getAddressCount() {
         return addressCount;
+    }
+
+    public BigDecimal getPi() {
+        return pi;
     }
 
 }

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/AddressProviderTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/AddressProviderTest.java
@@ -41,6 +41,9 @@ public class AddressProviderTest extends TestNGBase {
         softly.assertThat(NumberUtils.toInt(addressProviderDO.getAddressCount(), -1))
                 .as("State Address Count")
                 .isEqualTo(AddressProvider.getInstance().getAll(state).size());
+        softly.assertThat(addressProviderDO.getPi())
+                .as("PI (to 11 decimal places)")
+                .isEqualByComparingTo("3.14159265359");
         softly.assertAll();
     }
 

--- a/automation-tests/src/main/resources/data/api/JsonIp_TestData.xml
+++ b/automation-tests/src/main/resources/data/api/JsonIp_TestData.xml
@@ -18,5 +18,6 @@
 
         <geoIP>${geoIP}</geoIP>
         <apiHelp>${decApiHelp}</apiHelp>
+        <pi>3.14159265359</pi>
     </response>
 </json-ip-do>

--- a/automation-tests/src/main/resources/data/ui/GenericAddress_TestData.xml
+++ b/automation-tests/src/main/resources/data/ui/GenericAddress_TestData.xml
@@ -17,4 +17,5 @@
     </aliases>
     <addressInfo street="${street}" city="${city}" state="${state}" zipCode="${zipCode}" country="${country}" phoneNumber="${phoneNumber}"/>
     <addressCount>${addressCount}</addressCount>
+    <pi>3.14159265359</pi>
 </address-provider-do>

--- a/taf/src/main/java/com/taf/automation/api/converters/BigDecimalConverter.java
+++ b/taf/src/main/java/com/taf/automation/api/converters/BigDecimalConverter.java
@@ -1,0 +1,66 @@
+package com.taf.automation.api.converters;
+
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import datainstiller.data.DataValueConverter;
+import org.apache.commons.lang3.StringUtils;
+
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+
+/**
+ * Converter for BigDecimal
+ */
+public class BigDecimalConverter implements DataValueConverter {
+    /**
+     * Parses the specified string into an object (BigDecimal)
+     *
+     * @param str   - String to be parsed
+     * @param cls   - Is not used in this specific implementation
+     * @param field - Is not used in this specific implementation
+     * @return BigDecimal
+     */
+    @Override
+    public <T> T fromString(String str, Class<T> cls, Field field) {
+        BigDecimal bd;
+        try {
+            bd = (StringUtils.isNotBlank(str)) ? new BigDecimal(str) : null;
+        } catch (Exception ex) {
+            bd = BigDecimal.ZERO;
+        }
+
+        return (T) bd;
+    }
+
+    /**
+     * Convert an object (BigDecimal) to textual data.
+     *
+     * @param source  The object to be marshalled.
+     * @param writer  A stream to write to.
+     * @param context A context that allows nested objects to be processed by XStream.
+     */
+    @Override
+    public void marshal(Object source, HierarchicalStreamWriter writer, MarshallingContext context) {
+        writer.setValue(String.valueOf(source));
+    }
+
+    /**
+     * Convert textual data back into an object.
+     *
+     * @param reader  The stream to read the text from.
+     * @param context A context that allows nested objects to be processed by XStream.
+     * @return The resulting object (BigDecimal)
+     */
+    @Override
+    public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+        return fromString(reader.getValue(), BigDecimal.class, null);
+    }
+
+    @Override
+    public boolean canConvert(Class type) {
+        return BigDecimal.class.equals(type);
+    }
+
+}

--- a/taf/src/main/java/com/taf/automation/ui/support/DataPersistenceV2.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/DataPersistenceV2.java
@@ -8,6 +8,7 @@ import com.thoughtworks.xstream.converters.extended.ISO8601GregorianCalendarConv
 import datainstiller.data.DataGenerator;
 import datainstiller.data.DataPersistence;
 import org.apache.commons.jexl3.JexlContext;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 
 /**
@@ -18,7 +19,7 @@ import org.apache.commons.lang3.reflect.FieldUtils;
 @SuppressWarnings("java:S3252")
 public abstract class DataPersistenceV2 extends DataPersistence {
     @XStreamOmitField
-    private boolean useXstreamForAliases;
+    private Boolean useXstreamForAliases;
 
     protected DataPersistenceV2() {
         //
@@ -29,7 +30,7 @@ public abstract class DataPersistenceV2 extends DataPersistence {
     }
 
     protected void useNormalXstreamFlag() {
-        useXstreamForAliases = false;
+        useXstreamForAliases = null;
     }
 
     /**
@@ -60,7 +61,7 @@ public abstract class DataPersistenceV2 extends DataPersistence {
     @Override
     public XStream getXstream() {
         XStream xStream;
-        if (useXstreamForAliases) {
+        if (BooleanUtils.toBoolean(useXstreamForAliases)) {
             xStream = new XStream();
             xStream.registerConverter(new DataAliasesConverterV2(null));
             xStream.registerConverter(new ISO8601GregorianCalendarConverter());

--- a/taf/src/main/java/com/taf/automation/ui/support/util/DataInstillerUtils.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/util/DataInstillerUtils.java
@@ -1,6 +1,7 @@
 package com.taf.automation.ui.support.util;
 
 import com.taf.automation.api.converters.BasicHeaderConverter;
+import com.taf.automation.api.converters.BigDecimalConverter;
 import com.taf.automation.api.converters.EnumConverter;
 import com.taf.automation.ui.support.DataAliasesConverterV2;
 import com.taf.automation.ui.support.Environment;
@@ -41,9 +42,9 @@ public class DataInstillerUtils {
         RANDOM_DATE_GENERATOR("RandomDateGen", "RANDOM_DATE", new RandomDateGenerator()),
         RANDOM_US_ADDRESS_GENERATOR("RealUSAddressGen", "RANDOM_US_ADDRESS", new RandomRealUSAddressGenerator());
 
-        private String jexlKey;
-        private String registerKey;
-        private GeneratorInterface generator;
+        private final String jexlKey;
+        private final String registerKey;
+        private final GeneratorInterface generator;
 
         CustomGenerators(String jexlKey, String registerKey, GeneratorInterface generator) {
             this.jexlKey = jexlKey;
@@ -209,6 +210,7 @@ public class DataInstillerUtils {
         converters.add(new PageComponentDataConverter());
         converters.add(new BasicHeaderConverter());
         converters.add(new EnumConverter(EnvironmentType.class, Environment.QA));
+        converters.add(new BigDecimalConverter());
 
         return converters;
     }


### PR DESCRIPTION
By adding this BigDecimal Converter, you can generate the XML with BigDecimal variables.

Also, made useXstreamForAliases an object such that it can be omitted when in the ApiDomainObject.  This can be useful if you want to extend ApiDomainObject to get the functionality to generate xml and use it to be part of a request (as sending the useXstreamForAliases could cause issues should the server not ignore it where as if it is null it will not be sent.)