### PR TITLE
Upgrade ui_auto_core to the latest (2.5.21)

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/domainObjects/JexlExpressionDO.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/domainObjects/JexlExpressionDO.java
@@ -19,7 +19,7 @@ import java.util.Date;
 @SuppressWarnings({"squid:MaximumInheritanceDepth", "java:S3252"})
 @XStreamAlias("jexl-expression-do")
 public class JexlExpressionDO extends DomainObject {
-    private static final String TODAY = DateActions.format(new Date(), "MM/dd/yyyy");
+    private static final String TODAY = DateActions.format(new Date(), "yyyy-MM-dd");
     private static final String CURRENT_SYSTEM_DATE = "CURRENT_SYSTEM_DATE";
     private AliasedString someField;
     private AliasedString anotherField;

--- a/automation-tests/src/main/java/com/automation/common/ui/app/domainObjects/RandomDateUtil.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/domainObjects/RandomDateUtil.java
@@ -71,13 +71,13 @@ public class RandomDateUtil {
             return randomDate;
         }
 
-        String pattern = StringUtils.defaultString(PageComponentContext.getGlobalAliases().get(RANDOM_DATE_PATTERN));
+        String pattern = StringUtils.defaultString(PageComponentContext.getGlobalAliases().getAsString(RANDOM_DATE_PATTERN));
         pattern = (pattern.trim().equals("")) ? "yyyy-MM-dd" : pattern;
 
-        String start = StringUtils.defaultString(PageComponentContext.getGlobalAliases().get(RANDOM_DATE_RANGE_MIN));
+        String start = StringUtils.defaultString(PageComponentContext.getGlobalAliases().getAsString(RANDOM_DATE_RANGE_MIN));
         start = (start.equals("")) ? "0" : start;
 
-        String end = StringUtils.defaultString(PageComponentContext.getGlobalAliases().get(RANDOM_DATE_RANGE_MAX));
+        String end = StringUtils.defaultString(PageComponentContext.getGlobalAliases().getAsString(RANDOM_DATE_RANGE_MAX));
         end = (end.equals("")) ? "0" : end;
 
         int startInclusive = NumberUtils.toInt(start);

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/GenerateXmlTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/GenerateXmlTest.java
@@ -15,6 +15,8 @@ import com.automation.common.ui.app.pageObjects.HerokuappDataTablesPage;
 import com.automation.common.ui.app.pageObjects.HerokuappRow;
 import com.taf.automation.ui.support.testng.TestNGBase;
 import datainstiller.data.DataPersistence;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 import ru.yandex.qatools.allure.annotations.Features;
 import ru.yandex.qatools.allure.annotations.Severity;
@@ -30,6 +32,8 @@ import ru.yandex.qatools.allure.model.SeverityLevel;
  * should be tested when/if it occurs.
  */
 public class GenerateXmlTest extends TestNGBase {
+    private static final Logger LOG = LoggerFactory.getLogger(GenerateXmlTest.class);
+
     @Features("Framework")
     @Stories("Validate that XML generation works properly")
     @Severity(SeverityLevel.CRITICAL)
@@ -54,7 +58,8 @@ public class GenerateXmlTest extends TestNGBase {
 
     @Step("Generate XML for {0}")
     private void generateXml(String log, DataPersistence object) {
-        object.generate();
+        String xml = object.generateXML();
+        LOG.info("{}", xml);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <selenium.version>3.141.59</selenium.version>
         <selenium.edge.version>3.141.0</selenium.edge.version>
         <appium.version>7.3.0</appium.version>
-        <ui.auto.core.version>2.5.15</ui.auto.core.version>
+        <ui.auto.core.version>2.5.21</ui.auto.core.version>
         <testNg.version>7.4.0</testNg.version>
         <hamcrest.version>1.3</hamcrest.version>
         <jetty-server.version>9.4.3.v20170317</jetty-server.version>

--- a/taf/src/main/java/com/taf/automation/api/ApiDomainObject.java
+++ b/taf/src/main/java/com/taf/automation/api/ApiDomainObject.java
@@ -8,17 +8,17 @@ import com.taf.automation.api.clients.ApiLoginSession;
 import com.taf.automation.api.clients.UserLogin;
 import com.taf.automation.api.rest.GenericHttpResponse;
 import com.taf.automation.locking.UserLockManager;
-import com.taf.automation.ui.support.util.CryptoUtils;
 import com.taf.automation.ui.support.DataPersistenceV2;
-import com.taf.automation.ui.support.util.DomainObjectUtils;
-import com.taf.automation.ui.support.util.Helper;
 import com.taf.automation.ui.support.Lookup;
 import com.taf.automation.ui.support.TestProperties;
-import com.taf.automation.ui.support.util.Utils;
 import com.taf.automation.ui.support.converters.Credentials;
 import com.taf.automation.ui.support.converters.CreditCard;
 import com.taf.automation.ui.support.converters.DynamicCredentials;
 import com.taf.automation.ui.support.csv.CsvTestData;
+import com.taf.automation.ui.support.util.CryptoUtils;
+import com.taf.automation.ui.support.util.DomainObjectUtils;
+import com.taf.automation.ui.support.util.Helper;
+import com.taf.automation.ui.support.util.Utils;
 import com.thoughtworks.xstream.annotations.XStreamOmitField;
 import datainstiller.data.Data;
 import datainstiller.data.DataAliases;
@@ -34,7 +34,6 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -80,9 +79,9 @@ public class ApiDomainObject extends DataPersistenceV2 {
         createGlobalAliasses();
         String xml = super.toXML().replace(" xmlns=\"xmlns\" xmlns:xsi=\"xsi\" xsi:schemaLocation=\"schemaLocation\"", "");
 
-        for (Map.Entry<String, String> entry : dataAliases.entrySet()) {
-            String alias = "${" + entry.getKey() + "}";
-            String value = entry.getValue();
+        for (String key : dataAliases.keySet()) {
+            String alias = "${" + key + "}";
+            String value = dataAliases.getAsString(key);
             xml = xml.replace(alias, value);
         }
 

--- a/taf/src/main/java/com/taf/automation/ui/support/DataPersistenceV2.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/DataPersistenceV2.java
@@ -10,6 +10,7 @@ import datainstiller.data.DataPersistence;
 import org.apache.commons.jexl3.JexlContext;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
+import ui.auto.core.context.PageComponentContext;
 
 /**
  * The purpose of this class is to revert the removal of xml namespaces added to DataPersistence.  This was causing
@@ -63,7 +64,7 @@ public abstract class DataPersistenceV2 extends DataPersistence {
         XStream xStream;
         if (BooleanUtils.toBoolean(useXstreamForAliases)) {
             xStream = new XStream();
-            xStream.registerConverter(new DataAliasesConverterV2(null));
+            xStream.registerConverter(new DataAliasesConverterV2(null, PageComponentContext.getGlobalAliases()));
             xStream.registerConverter(new ISO8601GregorianCalendarConverter());
         } else {
             xStream = DataInstillerUtils.getXStream(getJexlContext());

--- a/taf/src/main/java/com/taf/automation/ui/support/TestContext.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/TestContext.java
@@ -95,7 +95,7 @@ public class TestContext extends PageComponentContext {
     }
 
     public String getAlias(String key) {
-        return getGlobalAliases().get(key);
+        return getGlobalAliases().getAsString(key);
     }
 
     public void setAlias(String key, String value) {

--- a/taf/src/main/java/com/taf/automation/ui/support/util/DataInstillerUtils.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/util/DataInstillerUtils.java
@@ -24,6 +24,7 @@ import datainstiller.generators.WordGenerator;
 import org.apache.commons.jexl3.JexlContext;
 import org.apache.commons.jexl3.MapContext;
 import org.apache.http.message.BasicHeader;
+import ui.auto.core.context.PageComponentContext;
 import ui.auto.core.data.PageComponentDataConverter;
 
 import java.time.LocalDateTime;
@@ -121,7 +122,7 @@ public class DataInstillerUtils {
         addCustomGenerators(jexlContext);
         XStream xstream = new XStream();
 
-        xstream.registerConverter(new DataAliasesConverterV2(jexlContext));
+        xstream.registerConverter(new DataAliasesConverterV2(jexlContext, PageComponentContext.getGlobalAliases()));
         xstream.registerConverter(new ISO8601GregorianCalendarConverter());
 
         return xstream;

--- a/taf/src/main/java/com/taf/automation/ui/support/util/DomainObjectUtils.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/util/DomainObjectUtils.java
@@ -24,7 +24,7 @@ public class DomainObjectUtils {
     private static List<Label> getLabels(DataAliases aliases, String labelAlias, LabelName labelName) {
         List<Label> labels = new ArrayList<>();
 
-        String label = aliases.get(labelAlias);
+        String label = aliases.getAsString(labelAlias);
         if (label != null) {
             for (String value : label.split(",")) {
                 labels.add(new Label().withName(labelName.value()).withValue(value.trim()));
@@ -45,8 +45,8 @@ public class DomainObjectUtils {
             return;
         }
 
-        String name = aliases.get("test-name");
-        String description = aliases.get("test-description");
+        String name = aliases.getAsString("test-name");
+        String description = aliases.getAsString("test-description");
 
         List<Label> labels = new ArrayList<>();
         labels.addAll(getLabels(aliases, "test-features", LabelName.FEATURE));


### PR DESCRIPTION
Changes in ui_auto_core to the latest (2.5.21):
- The DataAliases map has changed from <String, String> to <String, Object> which made the get method return an object instead of string.  There is a new method getAsString that can be used instead.
- In DataPersistence, the method generate has been made protected
- The DataAliasesConverter constructor changed to take aliases.  So, I made a similar change to DataAliasesConverterV2.