### PR TITLE
Add support to download files

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/Navigation.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/Navigation.java
@@ -67,6 +67,10 @@ public class Navigation {
         toURL("Herokuapp - Elements", props.getCustom("herokuapp-elements-url", null), cleanCookies);
     }
 
+    public void toHerokuappDownloads(boolean cleanCookies) {
+        toURL("Herokuapp - Downloads", props.getCustom("herokuapp-downloads-url", null), cleanCookies);
+    }
+
     public void toDuckDuckGo(boolean cleanCookies) {
         toURL("Duck Duck Go", props.getCustom("duckduckgo-url", null), cleanCookies);
     }

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/FileDownloaderTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/FileDownloaderTest.java
@@ -1,0 +1,90 @@
+package com.automation.common.ui.app.tests;
+
+import com.automation.common.ui.app.pageObjects.Navigation;
+import com.lazerycode.selenium.filedownloader.FileDownloader;
+import com.taf.automation.ui.support.testng.TestNGBase;
+import com.taf.automation.ui.support.util.AssertJUtil;
+import com.taf.automation.ui.support.util.DomainObjectUtils;
+import com.taf.automation.ui.support.util.FilloUtils;
+import com.taf.automation.ui.support.util.Utils;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.http.HttpStatus;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.testng.ITestContext;
+import org.testng.annotations.Test;
+import ru.yandex.qatools.allure.annotations.Features;
+import ru.yandex.qatools.allure.annotations.Severity;
+import ru.yandex.qatools.allure.annotations.Step;
+import ru.yandex.qatools.allure.annotations.Stories;
+import ru.yandex.qatools.allure.model.SeverityLevel;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Testing file downloading
+ */
+@SuppressWarnings("java:S3252")
+public class FileDownloaderTest extends TestNGBase {
+    private static final String LINK_HTTP_STATUS = "Link HTTP Status";
+
+    @Features("Framework")
+    @Stories("FileDownloader")
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void performTest(ITestContext injectedContext) {
+        DomainObjectUtils.overwriteTestName(injectedContext);
+        new Navigation(getContext()).toHerokuappDownloads(Utils.isCleanCookiesSupported());
+        FileDownloader downloader = new FileDownloader(getContext().getDriver());
+        downloadImageFromElement(downloader);
+        downloadImageFromHref(downloader);
+        downloadFileFromUri(downloader);
+    }
+
+    @Step("Perform Download Image from Element")
+    private void downloadImageFromElement(FileDownloader downloader) {
+        WebElement element = getContext().getDriver().findElement(By.cssSelector("[alt='Fork me on GitHub']"));
+        downloader.withURISpecifiedInImageElement(element);
+        int status = downloader.getLinkHTTPStatus();
+        AssertJUtil.assertThat(status).as(LINK_HTTP_STATUS).isEqualTo(HttpStatus.SC_OK);
+
+        File img = downloader.downloadFile();
+        img.deleteOnExit();
+        AssertJUtil.assertThat(img).exists().isFile();
+    }
+
+    @Step("Perform Download Image from HREF")
+    private void downloadImageFromHref(FileDownloader downloader) {
+        WebElement element = getContext().getDriver().findElement(By.xpath("//a[@href='download/chow.jpg']"));
+        downloader.withURISpecifiedInAnchorElement(element);
+        int status = downloader.getLinkHTTPStatus();
+        AssertJUtil.assertThat(status).as(LINK_HTTP_STATUS).isEqualTo(HttpStatus.SC_OK);
+
+        File img = downloader.downloadFile(".jpg");
+        img.deleteOnExit();
+        AssertJUtil.assertThat(img).exists().isFile();
+    }
+
+    @Step("Perform Download File from URI")
+    private void downloadFileFromUri(FileDownloader downloader) {
+        WebElement element = getContext().getDriver().findElement(By.xpath("//a[@href='download/people.xlsx']"));
+        downloader.withURI(element.getAttribute("href"));
+        int status = downloader.getLinkHTTPStatus();
+        AssertJUtil.assertThat(status).as(LINK_HTTP_STATUS).isEqualTo(HttpStatus.SC_OK);
+
+        File excel = downloader.downloadFile("auto-", ".xlsx");
+        excel.deleteOnExit();
+        AssertJUtil.assertThat(excel).exists().isFile();
+
+        List<CSVRecord> records = new ArrayList<>();
+        Map<String, Integer> headers = new HashMap<>();
+        FilloUtils.read(excel.getAbsolutePath(), "records", records, headers);
+        AssertJUtil.assertThat(records).as("Records").isNotEmpty();
+        AssertJUtil.assertThat(headers).as("Headers").isNotEmpty();
+    }
+
+}

--- a/automation-tests/src/main/resources/data/ui/sample-environment.xml
+++ b/automation-tests/src/main/resources/data/ui/sample-environment.xml
@@ -36,6 +36,7 @@
         <!-- URLs for tests.  We can store here instead of test.properties -->
         <prop name="herokuapp-tables-url" value="https://the-internet.herokuapp.com/tables"/>
         <prop name="herokuapp-elements-url" value="https://the-internet.herokuapp.com/add_remove_elements/"/>
+        <prop name="herokuapp-downloads-url" value="https://the-internet.herokuapp.com/download"/>
         <prop name="duckduckgo-url" value="https://duckduckgo.com/"/>
         <prop name="primefaces-dashboard-url" value="https://www.primefaces.org/showcase/ui/panel/dashboard.xhtml"/>
         <prop name="roboform-fill-url" value="https://www.roboform.com/filling-test-all-fields"/>

--- a/automation-tests/src/main/resources/suites/FrameworkSmokeTestSuite.xml
+++ b/automation-tests/src/main/resources/suites/FrameworkSmokeTestSuite.xml
@@ -430,6 +430,12 @@
         </classes>
     </test>
 
+    <test name="FileDownloader Test">
+        <classes>
+            <class name="com.automation.common.ui.app.tests.FileDownloaderTest"/>
+        </classes>
+    </test>
+
     <!--
     <test name="Open Report Test">
         <parameter name="allure-report" value="/target/allure-report"/>

--- a/taf/src/main/java/com/lazerycode/selenium/filedownloader/FileDownloader.java
+++ b/taf/src/main/java/com/lazerycode/selenium/filedownloader/FileDownloader.java
@@ -1,0 +1,295 @@
+package com.lazerycode.selenium.filedownloader;
+
+import com.taf.automation.api.clients.ApiClient;
+import com.taf.automation.ui.support.util.AssertJUtil;
+import org.apache.commons.io.FileUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.impl.cookie.BasicClientCookie;
+import org.apache.http.protocol.BasicHttpContext;
+import org.openqa.selenium.Cookie;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Set;
+
+/**
+ * The original code came from <a href="https://github.com/Ardesco/Powder-Monkey">https://github.com/Ardesco/Powder-Monkey</a>
+ * which was found on the <a href="https://ardesco.lazerycode.com/testing/webdriver/2012/07/25/how-to-download-files-with-selenium-and-why-you-shouldnt.html">blog by Mark Collin</a>
+ * <BR>
+ * Some modifications were made to remove use of deprecated methods and throwing of exceptions
+ */
+@SuppressWarnings("java:S3252")
+public class FileDownloader {
+    private final WebDriver driver;
+    private boolean followRedirects = true;
+    private boolean mimicWebDriverCookieState = true;
+    private RequestMethod httpRequestMethod = RequestMethod.GET;
+    private URI fileURI;
+
+    public FileDownloader(WebDriver driver) {
+        this.driver = driver;
+    }
+
+    /**
+     * Flag to indicate to follow re-directs
+     *
+     * @param followRedirects true to follow re-directs
+     * @return FileDownloader
+     */
+    public FileDownloader withFollowRedirects(boolean followRedirects) {
+        this.followRedirects = followRedirects;
+        return this;
+    }
+
+    /**
+     * Mimic the cookie state of WebDriver (Defaults to true)
+     * This will enable you to access files that are only available when logged in.
+     * If set to false the connection will be made as an anonymous user
+     *
+     * @param mimicWebDriverCookieState true to mimic the cookie state of WebDriver
+     * @return FileDownloader
+     */
+    public FileDownloader withMimicWebDriverCookieState(boolean mimicWebDriverCookieState) {
+        this.mimicWebDriverCookieState = mimicWebDriverCookieState;
+        return this;
+    }
+
+    /**
+     * Set the HTTP Request Method
+     *
+     * @param requestType - Request Type
+     * @return FileDownloader
+     */
+    public FileDownloader withHTTPRequestMethod(RequestMethod requestType) {
+        httpRequestMethod = requestType;
+        return this;
+    }
+
+    /**
+     * Specify a URL that you want to perform an HTTP Status Check upon/Download a file from
+     *
+     * @param linkToFile String
+     * @return FileDownloader
+     */
+    public FileDownloader withURI(String linkToFile) {
+        try {
+            fileURI = new URI(linkToFile);
+        } catch (URISyntaxException ex) {
+            AssertJUtil.fail("Could not create URI from (%s) due to exception:  %s", linkToFile, ex.getMessage());
+        }
+
+        return this;
+    }
+
+    /**
+     * Specify a URL that you want to perform an HTTP Status Check upon/Download a file from
+     *
+     * @param linkToFile URI
+     * @return FileDownloader
+     */
+    public FileDownloader withURI(URI linkToFile) {
+        fileURI = linkToFile;
+        return this;
+    }
+
+    /**
+     * Specify a URL that you want to perform an HTTP Status Check upon/Download a file from
+     *
+     * @param linkToFile URL
+     * @return FileDownloader
+     */
+    public FileDownloader withURI(URL linkToFile) {
+        try {
+            fileURI = linkToFile.toURI();
+        } catch (URISyntaxException ex) {
+            AssertJUtil.fail("Could not get URI (%s) due to exception:  %s", linkToFile, ex.getMessage());
+        }
+
+        return this;
+    }
+
+    /**
+     * Perform an HTTP Status Check upon/Download the file specified in the href attribute of a WebElement
+     *
+     * @param anchorElement Selenium WebElement
+     * @return FileDownloader
+     */
+    public FileDownloader withURISpecifiedInAnchorElement(WebElement anchorElement) {
+        if (anchorElement.getTagName().equals("a")) {
+            String href = anchorElement.getAttribute("href");
+            try {
+                fileURI = new URI(href);
+            } catch (URISyntaxException ex) {
+                AssertJUtil.fail("Could not parse href (%s) due to exception:  %s", href, ex.getMessage());
+            }
+        } else {
+            AssertJUtil.fail("You have not specified an <a> element!");
+        }
+
+        return this;
+    }
+
+    /**
+     * Perform an HTTP Status Check upon/Download the image specified in the src attribute of a WebElement
+     *
+     * @param imageElement Selenium WebElement
+     * @return FileDownloader
+     */
+    public FileDownloader withURISpecifiedInImageElement(WebElement imageElement) {
+        if (imageElement.getTagName().equals("img")) {
+            String src = imageElement.getAttribute("src");
+            try {
+                fileURI = new URI(src);
+            } catch (URISyntaxException ex) {
+                AssertJUtil.fail("Could not parse src (%s) due to exception:  %s", src, ex.getMessage());
+            }
+        } else {
+            AssertJUtil.fail("You have not specified an <img> element!");
+        }
+
+        return this;
+    }
+
+    /**
+     * Load in all the cookies WebDriver currently knows about so that we can mimic the browser cookie state
+     *
+     * @param seleniumCookieSet Set&lt;Cookie&gt;
+     * @return BasicCookieStore
+     */
+    private BasicCookieStore mimicCookieState(Set<Cookie> seleniumCookieSet) {
+        BasicCookieStore copyOfWebDriverCookieStore = new BasicCookieStore();
+        for (Cookie seleniumCookie : seleniumCookieSet) {
+            BasicClientCookie duplicateCookie = new BasicClientCookie(seleniumCookie.getName(), seleniumCookie.getValue());
+            duplicateCookie.setDomain(seleniumCookie.getDomain());
+            duplicateCookie.setSecure(seleniumCookie.isSecure());
+            duplicateCookie.setExpiryDate(seleniumCookie.getExpiry());
+            duplicateCookie.setPath(seleniumCookie.getPath());
+            copyOfWebDriverCookieStore.addCookie(duplicateCookie);
+        }
+
+        return copyOfWebDriverCookieStore;
+    }
+
+    private HttpResponse getHTTPResponse() throws IOException {
+        AssertJUtil.assertThat(fileURI).as("No file URI specified").isNotNull();
+
+        HttpClient client = new ApiClient().getClient();
+        BasicHttpContext localContext = new BasicHttpContext();
+
+        // Clear down the local cookie store every time to make sure we don't have any left over cookies influencing the test
+        localContext.setAttribute(HttpClientContext.COOKIE_STORE, null);
+        if (mimicWebDriverCookieState) {
+            localContext.setAttribute(HttpClientContext.COOKIE_STORE, mimicCookieState(driver.manage().getCookies()));
+        }
+
+        HttpRequestBase requestMethod = httpRequestMethod.getRequestMethod();
+        requestMethod.setURI(fileURI);
+        requestMethod.setConfig(RequestConfig.custom().setRedirectsEnabled(followRedirects).build());
+
+        return client.execute(requestMethod, localContext);
+    }
+
+    /**
+     * Gets the HTTP status code returned when trying to access the specified URI
+     *
+     * @return -1 if IOException occurs else status code
+     */
+    public int getLinkHTTPStatus() {
+        HttpResponse fileToDownload;
+        try {
+            fileToDownload = getHTTPResponse();
+        } catch (IOException io) {
+            return -1;
+        }
+
+        try {
+            return fileToDownload.getStatusLine().getStatusCode();
+        } finally {
+            if (fileToDownload.getEntity() != null) {
+                try {
+                    fileToDownload.getEntity().getContent().close();
+                } catch (IOException ignore) {
+                    // Ignore
+                }
+            }
+        }
+    }
+
+    /**
+     * Download a file from the specified URI to a temp file<BR>
+     * <B>Note: </B> The file should be marked for deletion using the deleteOnExit method.
+     *
+     * @return File
+     * @throws AssertionError in case of a problem or the connection was aborted
+     */
+    @SuppressWarnings("java:S2259")
+    public File downloadFile() {
+        return downloadFile(null);
+    }
+
+    /**
+     * Download a file from the specified URI to a temp file<BR>
+     * <B>Note: </B> The file should be marked for deletion using the deleteOnExit method.
+     *
+     * @param suffix - Suffix/Extension used to create the temp file.  (If null, then ".tmp" is used)
+     * @return File
+     * @throws AssertionError in case of a problem or the connection was aborted
+     */
+    @SuppressWarnings("java:S2259")
+    public File downloadFile(String suffix) {
+        return downloadFile(null, suffix);
+    }
+
+    /**
+     * Download a file from the specified URI to a temp file<BR>
+     * <B>Note: </B> The file should be marked for deletion using the deleteOnExit method.
+     *
+     * @param prefix - The prefix string to be used in generating the temp file's name
+     *               which must be at least three characters long. (If null, then "download" is used)
+     * @param suffix - Suffix/Extension used to create the temp file.  (If null, then ".tmp" is used)
+     * @return File
+     * @throws AssertionError in case of a problem or the connection was aborted
+     */
+    @SuppressWarnings("java:S2259")
+    public File downloadFile(String prefix, String suffix) {
+        File downloadedFile = null;
+        try {
+            downloadedFile = File.createTempFile(prefix == null ? "download" : prefix, suffix);
+        } catch (IOException io) {
+            AssertJUtil.fail("Failed to create temp file to due exception:  %s", io.getMessage());
+        }
+
+        HttpResponse fileToDownload = null;
+        try {
+            fileToDownload = getHTTPResponse();
+        } catch (IOException io) {
+            downloadedFile.deleteOnExit();
+            AssertJUtil.fail("Failed to download file to due exception:  %s", io.getMessage());
+        }
+
+        try {
+            FileUtils.copyInputStreamToFile(fileToDownload.getEntity().getContent(), downloadedFile);
+        } catch (IOException io) {
+            AssertJUtil.fail("Failed to copy the stream to the temp file to due exception:  %s", io.getMessage());
+        } finally {
+            try {
+                fileToDownload.getEntity().getContent().close();
+            } catch (IOException ignore) {
+                // Ignore
+            }
+        }
+
+        return downloadedFile;
+    }
+
+}

--- a/taf/src/main/java/com/lazerycode/selenium/filedownloader/RequestMethod.java
+++ b/taf/src/main/java/com/lazerycode/selenium/filedownloader/RequestMethod.java
@@ -1,0 +1,35 @@
+package com.lazerycode.selenium.filedownloader;
+
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpOptions;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.methods.HttpTrace;
+
+/**
+ * This code came from <a href="https://github.com/Ardesco/Powder-Monkey">https://github.com/Ardesco/Powder-Monkey</a>
+ * which was found on the <a href="https://ardesco.lazerycode.com/testing/webdriver/2012/07/25/how-to-download-files-with-selenium-and-why-you-shouldnt.html">blog by Mark Collin</a>
+ */
+public enum RequestMethod {
+    OPTIONS(new HttpOptions()),
+    GET(new HttpGet()),
+    HEAD(new HttpHead()),
+    POST(new HttpPost()),
+    PUT(new HttpPut()),
+    DELETE(new HttpDelete()),
+    TRACE(new HttpTrace());
+
+    private final HttpRequestBase request;
+
+    RequestMethod(HttpRequestBase requestMethod) {
+        request = requestMethod;
+    }
+
+    public HttpRequestBase getRequestMethod() {
+        return request;
+    }
+
+}

--- a/taf/src/main/java/com/taf/automation/api/clients/ApiClient.java
+++ b/taf/src/main/java/com/taf/automation/api/clients/ApiClient.java
@@ -146,6 +146,10 @@ public class ApiClient implements GenericHttpInterface {
         this.returnType = returnType;
     }
 
+    public CloseableHttpClient getClient() {
+        return client;
+    }
+
     private HttpHost getTargetHost(String url) {
         return HttpHost.create(url);
     }


### PR DESCRIPTION
Selenium itself cannot interact with system dialogs.  This prevents using Selenium to download files.  (It may be possible to have the files allows downloaded without interaction but this is a hack and not really maintainable.)  A cross platform solution was outlined in this [blog](https://ardesco.lazerycode.com/testing/webdriver/2012/07/25/how-to-download-files-with-selenium-and-why-you-shouldnt.html) using HttpClient.  It also included source code [here](https://github.com/Ardesco/Powder-Monkey).  I cleaned up the code and integrated it into the framework.