### PR TITLE
Add support to add header when downloading files

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/FileExamplesOtherFilesPage.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/FileExamplesOtherFilesPage.java
@@ -1,0 +1,67 @@
+package com.automation.common.ui.app.pageObjects;
+
+import com.lazerycode.selenium.filedownloader.FileDownloader;
+import com.taf.automation.ui.support.PageObjectV2;
+import com.taf.automation.ui.support.TestContext;
+import com.taf.automation.ui.support.util.AssertJUtil;
+import com.thoughtworks.xstream.annotations.XStreamOmitField;
+import org.apache.http.HttpStatus;
+import org.openqa.selenium.support.FindBy;
+import ui.auto.core.components.WebComponent;
+
+import java.io.File;
+
+/**
+ * This the Other Files page on the site <a href="https://file-examples.com/">File Examples</a>
+ */
+@SuppressWarnings("java:S3252")
+public class FileExamplesOtherFilesPage extends PageObjectV2 {
+    private static final String LINK_HTTP_STATUS = "Link HTTP Status";
+
+    @XStreamOmitField
+    @FindBy(css = "[download$='.csv']")
+    private WebComponent downloadSampleCsvFile;
+
+    public FileExamplesOtherFilesPage() {
+        super();
+    }
+
+    public FileExamplesOtherFilesPage(TestContext context) {
+        super(context);
+    }
+
+    /**
+     * Perform download of the CSV file using an element
+     *
+     * @return the CSV file that was saved to a temporary file which needs to be deleted after
+     */
+    public File performDownloadOfCsvFileUsingElement() {
+        FileDownloader downloader = new FileDownloader(getDriver());
+        downloader.withURISpecifiedInAnchorElement(downloadSampleCsvFile.getCoreElement());
+
+        // This is unnecessary and only for testing purposes
+        int status = downloader.getLinkHTTPStatus();
+        AssertJUtil.assertThat(status).as(LINK_HTTP_STATUS).isEqualTo(HttpStatus.SC_OK);
+
+        // For testing purposes, we are setting the suffix
+        return downloader.downloadFile(".csv");
+    }
+
+    /**
+     * Perform download of the CSV file using a URL
+     *
+     * @return the CSV file that was saved to a temporary file which needs to be deleted after
+     */
+    public File performDownloadOfCsvFileUsingUri() {
+        FileDownloader downloader = new FileDownloader(getDriver());
+        downloader.withURI(downloadSampleCsvFile.getAttribute("href"));
+
+        // This is unnecessary and only for testing purposes
+        int status = downloader.getLinkHTTPStatus();
+        AssertJUtil.assertThat(status).as(LINK_HTTP_STATUS).isEqualTo(HttpStatus.SC_OK);
+
+        // For testing purposes, we are setting the both the prefix & suffix
+        return downloader.downloadFile("auto-", ".csv");
+    }
+
+}

--- a/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/Navigation.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/Navigation.java
@@ -103,4 +103,8 @@ public class Navigation {
         toURL("Selenium Easy - Basic Checkbox", props.getCustom("seleniumeasy-basic-checkbox-url", null), cleanCookies);
     }
 
+    public void toFileExamplesOtherFiles(boolean cleanCookies) {
+        toURL("File Examples - Other Files", props.getCustom("file-examples-other-files-url", null), cleanCookies);
+    }
+
 }

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/FileDownloaderTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/FileDownloaderTest.java
@@ -9,6 +9,7 @@ import com.taf.automation.ui.support.util.FilloUtils;
 import com.taf.automation.ui.support.util.Utils;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.http.HttpStatus;
+import org.apache.http.message.BasicHeader;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.testng.ITestContext;
@@ -73,6 +74,11 @@ public class FileDownloaderTest extends TestNGBase {
     private void downloadFileFromUri(FileDownloader downloader) {
         WebElement element = getContext().getDriver().findElement(By.xpath("//a[@href='download/people.xlsx']"));
         downloader.withURI(element.getAttribute("href"));
+
+        // Test adding headers & then resetting back to empty
+        downloader.withRequestHeader("testA", "something").withRequestHeader(new BasicHeader("testB", "xyz"));
+        downloader.resetRequestHeaders();
+
         int status = downloader.getLinkHTTPStatus();
         AssertJUtil.assertThat(status).as(LINK_HTTP_STATUS).isEqualTo(HttpStatus.SC_OK);
 

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/FileDownloaderTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/FileDownloaderTest.java
@@ -1,15 +1,15 @@
 package com.automation.common.ui.app.tests;
 
+import com.automation.common.ui.app.pageObjects.FileExamplesOtherFilesPage;
 import com.automation.common.ui.app.pageObjects.Navigation;
 import com.lazerycode.selenium.filedownloader.FileDownloader;
+import com.taf.automation.ui.support.csv.CsvUtils;
 import com.taf.automation.ui.support.testng.TestNGBase;
 import com.taf.automation.ui.support.util.AssertJUtil;
 import com.taf.automation.ui.support.util.DomainObjectUtils;
-import com.taf.automation.ui.support.util.FilloUtils;
 import com.taf.automation.ui.support.util.Utils;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.http.HttpStatus;
-import org.apache.http.message.BasicHeader;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.testng.ITestContext;
@@ -31,8 +31,6 @@ import java.util.Map;
  */
 @SuppressWarnings("java:S3252")
 public class FileDownloaderTest extends TestNGBase {
-    private static final String LINK_HTTP_STATUS = "Link HTTP Status";
-
     @Features("Framework")
     @Stories("FileDownloader")
     @Severity(SeverityLevel.CRITICAL)
@@ -40,55 +38,42 @@ public class FileDownloaderTest extends TestNGBase {
     public void performTest(ITestContext injectedContext) {
         DomainObjectUtils.overwriteTestName(injectedContext);
         new Navigation(getContext()).toHerokuappDownloads(Utils.isCleanCookiesSupported());
-        FileDownloader downloader = new FileDownloader(getContext().getDriver());
-        downloadImageFromElement(downloader);
-        downloadImageFromHref(downloader);
-        downloadFileFromUri(downloader);
+        downloadImageFromElement();
+
+        new Navigation(getContext()).toFileExamplesOtherFiles(Utils.isCleanCookiesSupported());
+        downloadImageFromHref();
+        downloadFileFromUri();
     }
 
     @Step("Perform Download Image from Element")
-    private void downloadImageFromElement(FileDownloader downloader) {
+    private void downloadImageFromElement() {
+        FileDownloader downloader = new FileDownloader(getContext().getDriver());
         WebElement element = getContext().getDriver().findElement(By.cssSelector("[alt='Fork me on GitHub']"));
         downloader.withURISpecifiedInImageElement(element);
         int status = downloader.getLinkHTTPStatus();
-        AssertJUtil.assertThat(status).as(LINK_HTTP_STATUS).isEqualTo(HttpStatus.SC_OK);
+        AssertJUtil.assertThat(status).as("Link HTTP Status").isEqualTo(HttpStatus.SC_OK);
 
         File img = downloader.downloadFile();
         img.deleteOnExit();
         AssertJUtil.assertThat(img).exists().isFile();
     }
 
-    @Step("Perform Download Image from HREF")
-    private void downloadImageFromHref(FileDownloader downloader) {
-        WebElement element = getContext().getDriver().findElement(By.xpath("//a[@href='download/chow.jpg']"));
-        downloader.withURISpecifiedInAnchorElement(element);
-        int status = downloader.getLinkHTTPStatus();
-        AssertJUtil.assertThat(status).as(LINK_HTTP_STATUS).isEqualTo(HttpStatus.SC_OK);
-
-        File img = downloader.downloadFile(".jpg");
+    @Step("Perform Download CSV from HREF")
+    private void downloadImageFromHref() {
+        File img = new FileExamplesOtherFilesPage(getContext()).performDownloadOfCsvFileUsingElement();
         img.deleteOnExit();
         AssertJUtil.assertThat(img).exists().isFile();
     }
 
     @Step("Perform Download File from URI")
-    private void downloadFileFromUri(FileDownloader downloader) {
-        WebElement element = getContext().getDriver().findElement(By.xpath("//a[@href='download/people.xlsx']"));
-        downloader.withURI(element.getAttribute("href"));
-
-        // Test adding headers & then resetting back to empty
-        downloader.withRequestHeader("testA", "something").withRequestHeader(new BasicHeader("testB", "xyz"));
-        downloader.resetRequestHeaders();
-
-        int status = downloader.getLinkHTTPStatus();
-        AssertJUtil.assertThat(status).as(LINK_HTTP_STATUS).isEqualTo(HttpStatus.SC_OK);
-
-        File excel = downloader.downloadFile("auto-", ".xlsx");
+    private void downloadFileFromUri() {
+        File excel = new FileExamplesOtherFilesPage(getContext()).performDownloadOfCsvFileUsingUri();
         excel.deleteOnExit();
         AssertJUtil.assertThat(excel).exists().isFile();
 
         List<CSVRecord> records = new ArrayList<>();
         Map<String, Integer> headers = new HashMap<>();
-        FilloUtils.read(excel.getAbsolutePath(), "records", records, headers);
+        CsvUtils.read(excel.getAbsolutePath(), records, headers);
         AssertJUtil.assertThat(records).as("Records").isNotEmpty();
         AssertJUtil.assertThat(headers).as("Headers").isNotEmpty();
     }

--- a/automation-tests/src/main/resources/data/ui/sample-environment.xml
+++ b/automation-tests/src/main/resources/data/ui/sample-environment.xml
@@ -45,6 +45,7 @@
         <prop name="rubywatir-checkboxes-url" value="http://test.rubywatir.com/checkboxes.php"/>
         <prop name="seleniumeasy-radio-button-url" value="https://www.seleniumeasy.com/test/input-form-demo.html"/>
         <prop name="seleniumeasy-basic-checkbox-url" value="https://www.seleniumeasy.com/test/basic-checkbox-demo.html"/>
+        <prop name="file-examples-other-files-url" value="https://file-examples.com/index.php/text-files-and-archives-download/"/>
 
         <!-- There is bug in UserProvider class of ui_auto_core 2.5.15 that requires at least 1 user with a role -->
         <user role="user" userName="u2" password="xzRZ75G077/YqCsRSAHGMw=="/>

--- a/taf/src/main/java/com/lazerycode/selenium/filedownloader/FileDownloader.java
+++ b/taf/src/main/java/com/lazerycode/selenium/filedownloader/FileDownloader.java
@@ -3,6 +3,7 @@ package com.lazerycode.selenium.filedownloader;
 import com.taf.automation.api.clients.ApiClient;
 import com.taf.automation.ui.support.util.AssertJUtil;
 import org.apache.commons.io.FileUtils;
+import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
@@ -10,6 +11,7 @@ import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.cookie.BasicClientCookie;
+import org.apache.http.message.BasicHeader;
 import org.apache.http.protocol.BasicHttpContext;
 import org.openqa.selenium.Cookie;
 import org.openqa.selenium.WebDriver;
@@ -20,6 +22,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -35,6 +39,7 @@ public class FileDownloader {
     private boolean mimicWebDriverCookieState = true;
     private RequestMethod httpRequestMethod = RequestMethod.GET;
     private URI fileURI;
+    private final List<Header> headers = new ArrayList<>();
 
     public FileDownloader(WebDriver driver) {
         this.driver = driver;
@@ -161,6 +166,39 @@ public class FileDownloader {
     }
 
     /**
+     * Add Request Header to be sent
+     *
+     * @param header - Request Header
+     * @return FileDownloader
+     */
+    public FileDownloader withRequestHeader(Header header) {
+        headers.add(header);
+        return this;
+    }
+
+    /**
+     * Add Request Header to be sent
+     *
+     * @param name  - Header Name
+     * @param value - Header value
+     * @return FileDownloader
+     */
+    public FileDownloader withRequestHeader(String name, String value) {
+        Header header = new BasicHeader(name, value);
+        return withRequestHeader(header);
+    }
+
+    /**
+     * Reset the request headers back to the empty list
+     *
+     * @return FileDownloader
+     */
+    public FileDownloader resetRequestHeaders() {
+        headers.clear();
+        return this;
+    }
+
+    /**
      * Load in all the cookies WebDriver currently knows about so that we can mimic the browser cookie state
      *
      * @param seleniumCookieSet Set&lt;Cookie&gt;
@@ -195,6 +233,7 @@ public class FileDownloader {
         HttpRequestBase requestMethod = httpRequestMethod.getRequestMethod();
         requestMethod.setURI(fileURI);
         requestMethod.setConfig(RequestConfig.custom().setRedirectsEnabled(followRedirects).build());
+        headers.forEach(requestMethod::setHeader);
 
         return client.execute(requestMethod, localContext);
     }

--- a/taf/src/main/java/com/lazerycode/selenium/filedownloader/RequestMethod.java
+++ b/taf/src/main/java/com/lazerycode/selenium/filedownloader/RequestMethod.java
@@ -2,25 +2,22 @@ package com.lazerycode.selenium.filedownloader;
 
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpOptions;
+import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.methods.HttpTrace;
 
 /**
  * This code came from <a href="https://github.com/Ardesco/Powder-Monkey">https://github.com/Ardesco/Powder-Monkey</a>
  * which was found on the <a href="https://ardesco.lazerycode.com/testing/webdriver/2012/07/25/how-to-download-files-with-selenium-and-why-you-shouldnt.html">blog by Mark Collin</a>
  */
 public enum RequestMethod {
-    OPTIONS(new HttpOptions()),
     GET(new HttpGet()),
-    HEAD(new HttpHead()),
     POST(new HttpPost()),
     PUT(new HttpPut()),
     DELETE(new HttpDelete()),
-    TRACE(new HttpTrace());
+    PATCH(new HttpPatch()),
+    ;
 
     private final HttpRequestBase request;
 

--- a/taf/src/main/java/com/taf/automation/api/clients/ApiClient.java
+++ b/taf/src/main/java/com/taf/automation/api/clients/ApiClient.java
@@ -146,7 +146,7 @@ public class ApiClient implements GenericHttpInterface {
         this.returnType = returnType;
     }
 
-    public CloseableHttpClient getClient() {
+    CloseableHttpClient getClient() {
         return client;
     }
 

--- a/taf/src/main/java/com/taf/automation/api/clients/FileDownloaderClient.java
+++ b/taf/src/main/java/com/taf/automation/api/clients/FileDownloaderClient.java
@@ -1,0 +1,24 @@
+package com.taf.automation.api.clients;
+
+import com.taf.automation.api.ParametersType;
+import com.taf.automation.api.ReturnType;
+import com.taf.automation.ui.support.TestProperties;
+import org.apache.http.impl.client.CloseableHttpClient;
+
+/**
+ * Wrapper class to provide a CloseableHttpClient for use in the FileDownloader class without exposing it to all classes
+ */
+public class FileDownloaderClient {
+    private static final String URL = "https://www.google.com"; // Any valid url
+    private static final int TIMEOUT = TestProperties.getInstance().getApiTimeout();
+    private final ApiClient apiClient;
+
+    public FileDownloaderClient() {
+        apiClient = new ApiClient(ParametersType.GENERAL, ReturnType.GENERAL, URL, null, null, TIMEOUT, TIMEOUT);
+    }
+
+    public CloseableHttpClient getClient() {
+        return apiClient.getClient();
+    }
+
+}


### PR DESCRIPTION
This will enable downloading files that are protected by XSS and/or CSRF by adding the proper headers.