### PR TITLE
Add status code check when downloading file

### DIFF
--- a/taf/src/main/java/com/lazerycode/selenium/filedownloader/FileDownloader.java
+++ b/taf/src/main/java/com/lazerycode/selenium/filedownloader/FileDownloader.java
@@ -7,6 +7,7 @@ import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpRequestBase;
@@ -345,6 +346,12 @@ public class FileDownloader {
         }
 
         try {
+            AssertJUtil.assertThat(fileToDownload.getStatusLine())
+                    .as("Download File - Status Line")
+                    .isNotNull();
+            AssertJUtil.assertThat(fileToDownload.getStatusLine().getStatusCode())
+                    .as("Download File - Status Code")
+                    .isLessThan(HttpStatus.SC_BAD_REQUEST);
             FileUtils.copyInputStreamToFile(fileToDownload.getEntity().getContent(), downloadedFile);
         } catch (IOException io) {
             AssertJUtil.fail("Failed to copy the stream to the temp file to due exception:  %s", io.getMessage());


### PR DESCRIPTION
The server may return an error code if you are not authorized to download the file.  (This could be due to any number of reasons including missing XSS and/or CSRF information for the request.)  In these cases, the file returned will probably be an error page instead of the desired file.  So, I have added validation to ensure the status code is not an error.