### PR TITLE
Add wrapper methods of commonly used FileUtils methods

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/api/domainObjects/MultipartEntityDO.java
+++ b/automation-tests/src/main/java/com/automation/common/api/domainObjects/MultipartEntityDO.java
@@ -3,17 +3,16 @@ package com.automation.common.api.domainObjects;
 import com.taf.automation.api.MicroServiceDomainObject;
 import com.taf.automation.api.clients.MicroServiceResponse;
 import com.taf.automation.ui.support.util.AssertJUtil;
+import com.taf.automation.ui.support.util.DownloadUtils;
 import com.taf.automation.ui.support.util.Helper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamOmitField;
-import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.message.BasicStatusLine;
 import ru.yandex.qatools.allure.annotations.Step;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 
 @SuppressWarnings({"java:S110", "java:S3252"})
@@ -40,13 +39,7 @@ public class MultipartEntityDO extends MicroServiceDomainObject {
                 InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(filePath);
                 File file = new File(filePath);
                 AssertJUtil.assertThat(is).as("Image file '" + filePath + "' was not found!").isNotNull();
-                try {
-                    FileUtils.copyInputStreamToFile(is, file);
-                    is.close();
-                } catch (IOException ignored) {
-                    //
-                }
-
+                DownloadUtils.writeFile(is, file);
                 builder.addBinaryBody("file", file);
             }
 

--- a/automation-tests/src/main/java/com/automation/common/ui/app/components/ImageUpload.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/components/ImageUpload.java
@@ -2,8 +2,8 @@ package com.automation.common.ui.app.components;
 
 import com.taf.automation.ui.support.TestProperties;
 import com.taf.automation.ui.support.util.AssertJUtil;
+import com.taf.automation.ui.support.util.DownloadUtils;
 import com.taf.automation.ui.support.util.Utils;
-import org.apache.commons.io.FileUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.LocalFileDetector;
@@ -12,7 +12,6 @@ import org.openqa.selenium.remote.RemoteWebElement;
 import ui.auto.core.pagecomponent.PageComponentNoDefaultAction;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -63,12 +62,7 @@ public class ImageUpload extends PageComponentNoDefaultAction {
             //
             // Need to copy the resource from the JAR to the local file system such that it can be uploaded
             //
-            try {
-                FileUtils.copyInputStreamToFile(is, file);
-                is.close();
-            } catch (IOException ignored) {
-                //
-            }
+            DownloadUtils.writeFile(is, file);
 
             //
             // Only necessary if using Grid
@@ -82,7 +76,7 @@ public class ImageUpload extends PageComponentNoDefaultAction {
             //
             inputUploadFile.sendKeys(file.getAbsolutePath());
             List<WebElement> images = driver.findElements(By.cssSelector(".spinner"));
-            if (images.size() > 0) {
+            if (!images.isEmpty()) {
                 Utils.waitForElementToHide(images.get(0));
             }
 

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/ExcelTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/ExcelTest.java
@@ -2,10 +2,10 @@ package com.automation.common.ui.app.tests;
 
 import com.taf.automation.ui.support.testng.AllureTestNGListener;
 import com.taf.automation.ui.support.util.AssertJUtil;
+import com.taf.automation.ui.support.util.DownloadUtils;
 import com.taf.automation.ui.support.util.ExcelUtils;
 import com.taf.automation.ui.support.util.FilloUtils;
 import com.taf.automation.ui.support.util.Helper;
-import org.apache.commons.io.FileUtils;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Optional;
 import org.testng.annotations.Parameters;
@@ -122,8 +122,8 @@ public class ExcelTest {
     public void validateMethodsGetSameData(@Optional(EXCEL_FILE) String dataSet, @Optional(SHEET_1) String worksheet) throws IOException {
         String[][] resourceData = ExcelUtils.getAllData(dataSet, worksheet);
 
-        File fileSource = File.createTempFile("excel", "");
-        FileUtils.copyInputStreamToFile(Thread.currentThread().getContextClassLoader().getResourceAsStream(dataSet), fileSource);
+        File fileSource = DownloadUtils.createTempFile("excel", "");
+        DownloadUtils.writeFile(Thread.currentThread().getContextClassLoader().getResourceAsStream(dataSet), fileSource);
         String[][] fileData = ExcelUtils.getAllData(fileSource.toURI().toURL().getFile(), worksheet);
         fileSource.deleteOnExit();
         AssertJUtil.assertThat(resourceData).as("Methods did not load data the same").isEqualTo(fileData);

--- a/automation-tests/src/main/java/com/automation/common/ui/app/tests/FileDownloaderTest.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/tests/FileDownloaderTest.java
@@ -8,9 +8,9 @@ import com.taf.automation.ui.support.csv.CsvUtils;
 import com.taf.automation.ui.support.testng.TestNGBase;
 import com.taf.automation.ui.support.util.AssertJUtil;
 import com.taf.automation.ui.support.util.DomainObjectUtils;
+import com.taf.automation.ui.support.util.DownloadUtils;
 import com.taf.automation.ui.support.util.Utils;
 import org.apache.commons.csv.CSVRecord;
-import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpStatus;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -76,7 +76,7 @@ public class FileDownloaderTest extends TestNGBase {
         File csv = new FileExamplesOtherFilesPage(getContext()).performDownloadOfCsvFileUsingUri();
         csv.deleteOnExit();
         AssertJUtil.assertThat(csv).exists().isFile();
-        genericCsvValidations(csv);
+        genericCsvValidations(csv, "CSV from URI");
         return csv;
     }
 
@@ -85,31 +85,23 @@ public class FileDownloaderTest extends TestNGBase {
         File csv = new FileExamplesOtherFilesPage(getContext()).performDownloadOfCsvFileUsingJavaScript();
         csv.deleteOnExit();
         AssertJUtil.assertThat(csv).exists().isFile();
-        genericCsvValidations(csv);
+        genericCsvValidations(csv, "CSV using JavaScript");
         return csv;
     }
 
-    private void genericCsvValidations(File csv) {
+    private void genericCsvValidations(File csv, String attachmentName) {
         List<CSVRecord> records = new ArrayList<>();
         Map<String, Integer> headers = new HashMap<>();
         CsvUtils.read(csv.getAbsolutePath(), records, headers);
         AssertJUtil.assertThat(records).as("Records").isNotEmpty();
         AssertJUtil.assertThat(headers).as("Headers").isNotEmpty();
-        ApiUtils.attachDataFile(csv, "text/csv", "CSV using JavaScript");
+        ApiUtils.attachDataFile(csv, "text/csv", attachmentName);
     }
 
     @Step("Validate CSV Files Are Equal")
     private void validateCsvFilesAreEqual(File csvUri, File csvJs) {
-        Boolean result;
-        try {
-            result = FileUtils.contentEquals(csvUri, csvUri);
-        } catch (Exception ex) {
-            result = null;
-        }
-
-        AssertJUtil.assertThat(result)
-                .as("Error occurred reading the files").isNotNull()
-                .as("CSV URI vs. CSV JS").isTrue();
+        boolean result = DownloadUtils.contentEquals(csvUri, csvJs);
+        AssertJUtil.assertThat(result).as("CSV URI vs. CSV JS").isTrue();
     }
 
 }

--- a/taf/src/main/java/com/taf/automation/db/SqlServerInstance.java
+++ b/taf/src/main/java/com/taf/automation/db/SqlServerInstance.java
@@ -3,7 +3,7 @@ package com.taf.automation.db;
 import com.taf.automation.ui.support.TestProperties;
 import com.taf.automation.ui.support.util.AssertJUtil;
 import com.taf.automation.ui.support.util.CryptoUtils;
-import org.apache.commons.io.FileUtils;
+import com.taf.automation.ui.support.util.DownloadUtils;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 
@@ -77,12 +77,12 @@ public class SqlServerInstance extends DBInstance {
             LOG.info("Setting up for Integrated Security");
 
             URL source = Thread.currentThread().getContextClassLoader().getResource(getResource());
-            File fileSource = File.createTempFile("sqlDriver", "");
-            FileUtils.copyURLToFile(source, fileSource);
+            File fileSource = DownloadUtils.createTempFile("sqlDriver", "");
+            DownloadUtils.copyURLToFile(source, fileSource);
 
             File destination = new File(INSTALL_DLL + SEPARATOR + DLL);
-            if (!FileUtils.contentEquals(fileSource, destination)) {
-                FileUtils.copyFile(fileSource, destination);
+            if (!DownloadUtils.contentEquals(fileSource, destination)) {
+                DownloadUtils.copyFile(fileSource, destination);
                 destination.setExecutable(true, true);
                 LOG.info("Copied DLL to location:  {}{}{}", INSTALL_DLL, SEPARATOR, DLL);
             }

--- a/taf/src/main/java/com/taf/automation/ui/support/TestRunner.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/TestRunner.java
@@ -1,6 +1,7 @@
 package com.taf.automation.ui.support;
 
 import com.taf.automation.ui.support.testng.TestParameterValidator;
+import com.taf.automation.ui.support.util.DownloadUtils;
 import com.thoughtworks.xstream.XStream;
 import io.qameta.allure.Commands;
 import io.qameta.allure.option.ConfigOptions;
@@ -13,7 +14,6 @@ import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.openqa.selenium.net.PortProber;
-import org.testng.ITestNGListener;
 import org.testng.TestNG;
 import org.testng.reporters.Files;
 import ru.yandex.qatools.commons.model.Environment;
@@ -50,14 +50,14 @@ public class TestRunner {
             InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(suite);
             File file = new File(suite);
             if (is != null) {
-                FileUtils.copyInputStreamToFile(is, file);
+                DownloadUtils.writeFile(is, file);
             } else if (!file.exists()) {
                 throw new IOException("Suite file '" + suite + "' does not exists on the file system!");
             }
         }
 
         TestNG testNg = new TestNG();
-        testNg.addListener((ITestNGListener) new TestParameterValidator());
+        testNg.addListener(new TestParameterValidator());
         testNg.setTestSuites(suites);
         testNg.setSuiteThreadPoolSize(1);
         testNg.run();
@@ -65,11 +65,11 @@ public class TestRunner {
         return testNg.getStatus();
     }
 
-    public void generateReport() throws ZipException, IOException {
+    public void generateReport() throws ZipException {
         generateReport(reportFolder, resultsFolder);
     }
 
-    public void generateReport(String outputFolder, String... inputFolders) throws ZipException, IOException {
+    public void generateReport(String outputFolder, String... inputFolders) throws ZipException {
         Path reportDirectory = new File(outputFolder).toPath();
 
         List<Path> resultsDirectories = new ArrayList<>();
@@ -98,10 +98,10 @@ public class TestRunner {
      * </LI>
      * </OL>
      */
-    private void extractFilesForAllure2ReportGeneration() throws ZipException, IOException {
+    private void extractFilesForAllure2ReportGeneration() throws ZipException {
         URL source = Thread.currentThread().getContextClassLoader().getResource(ALLURE2_CLI);
         File destination = new File(REPORT_CLI + SEPARATOR + ALLURE2_CLI);
-        FileUtils.copyURLToFile(source, destination);
+        DownloadUtils.copyURLToFile(source, destination);
         ZipFile zipFile = new ZipFile(destination);
         zipFile.extractAll(REPORT_CLI.getAbsolutePath());
     }

--- a/taf/src/main/java/com/taf/automation/ui/support/testng/TestNGBaseWithoutListeners.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/testng/TestNGBaseWithoutListeners.java
@@ -4,11 +4,11 @@ import com.taf.automation.api.html.HtmlUtils;
 import com.taf.automation.ui.support.DomainObject;
 import com.taf.automation.ui.support.TestContext;
 import com.taf.automation.ui.support.TestProperties;
+import com.taf.automation.ui.support.util.DownloadUtils;
 import com.taf.automation.ui.support.util.ExpectedConditionsUtil;
 import com.taf.automation.ui.support.util.Utils;
 import datainstiller.data.DataPersistence;
 import io.appium.java_client.AppiumDriver;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.slf4j.Logger;
@@ -21,7 +21,6 @@ import org.testng.annotations.BeforeTest;
 import ui.auto.core.pagecomponent.PageObject;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Date;
@@ -121,16 +120,12 @@ public class TestNGBaseWithoutListeners {
         }
 
         String driverPath = System.getProperty("user.home") + subFolder + driverName + extension;
-        try {
-            File fileTarget = new File(driverPath);
-            File fileSource = File.createTempFile("driverName", "");
-            FileUtils.copyInputStreamToFile(getClass().getResourceAsStream(resourceSubFolder + driverName + extension), fileSource);
-            if (!FileUtils.contentEquals(fileSource, fileTarget)) {
-                FileUtils.copyFile(fileSource, fileTarget);
-                fileTarget.setExecutable(true, true);
-            }
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+        File fileTarget = new File(driverPath);
+        File fileSource = DownloadUtils.createTempFile("driverName", "");
+        DownloadUtils.writeFile(getClass().getResourceAsStream(resourceSubFolder + driverName + extension), fileSource);
+        if (!DownloadUtils.contentEquals(fileSource, fileTarget)) {
+            DownloadUtils.copyFile(fileSource, fileTarget);
+            fileTarget.setExecutable(true, true);
         }
 
         System.setProperty(driverPropertyName, driverPath);

--- a/taf/src/main/java/com/taf/automation/ui/support/util/DownloadUtils.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/util/DownloadUtils.java
@@ -4,6 +4,8 @@ import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
 
 @SuppressWarnings("java:S3252")
 public class DownloadUtils {
@@ -43,6 +45,64 @@ public class DownloadUtils {
             FileUtils.writeByteArrayToFile(file, data);
         } catch (IOException io) {
             AssertJUtil.fail("Failed to write file to due exception:  %s", io.getMessage());
+        }
+    }
+
+    /**
+     * Wrapper of FileUtils.copyInputStreamToFile that does not require handling of the exception
+     *
+     * @param source      - the InputStream to copy bytes from, must not be null, will be closed
+     * @param destination - the non-directory File to write bytes to (possibly overwriting), must not be null
+     */
+    public static void writeFile(InputStream source, File destination) {
+        try {
+            FileUtils.copyInputStreamToFile(source, destination);
+        } catch (IOException io) {
+            AssertJUtil.fail("Failed to copy the stream to the file to due exception:  %s", io.getMessage());
+        }
+    }
+
+    /**
+     * Wrapper of FileUtils.copyFile that does not require handling of the exception
+     *
+     * @param fileSource - an existing file to copy, must not be null
+     * @param fileTarget - the new file, must not be null
+     */
+    public static void copyFile(File fileSource, File fileTarget) {
+        try {
+            FileUtils.copyFile(fileSource, fileTarget);
+        } catch (IOException io) {
+            AssertJUtil.fail("Failed to copy the file to due exception:  %s", io.getMessage());
+        }
+    }
+
+    /**
+     * Wrapper of FileUtils.copyURLToFile that does not require handling of the exception
+     *
+     * @param source      - the URL to copy bytes from, must not be null
+     * @param destination - the non-directory File to write bytes to (possibly overwriting), must not be null
+     */
+    public static void copyURLToFile(URL source, File destination) {
+        try {
+            FileUtils.copyURLToFile(source, destination);
+        } catch (IOException io) {
+            AssertJUtil.fail("Failed to copy the URL to file to due exception:  %s", io.getMessage());
+        }
+    }
+
+    /**
+     * Wrapper of FileUtils.contentEquals that does not require handling of the exception
+     *
+     * @param lhs - the first file
+     * @param rhs - the second file
+     * @return true if the content of the files are equal or they both don't exist, false otherwise
+     */
+    public static boolean contentEquals(File lhs, File rhs) {
+        try {
+            return FileUtils.contentEquals(lhs, rhs);
+        } catch (IOException io) {
+            AssertJUtil.fail("Failed to read the files to due exception:  %s", io.getMessage());
+            return false;
         }
     }
 


### PR DESCRIPTION
- This is just for convenience as these methods throw IOException which need to handled.
- Re-factored the code to use these wrapped methods
- Fix attached name of the CSV file
- Fix issue with comparing the CSV files
- Add support to change the status code for successful download