### PR TITLE
Better handle disabled drop downs

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/components/SelectEnhanced.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/components/SelectEnhanced.java
@@ -227,10 +227,6 @@ public class SelectEnhanced extends PageComponent {
     }
 
     private void setValueAttempt() {
-        // Selenium allows disabled drop downs to still be set.
-        // So, to prevent this we will assert that it is enabled before setting the value
-        AssertJUtil.assertThat(isEnabled()).as("Select was disabled").isTrue();
-
         if (getSelection() == Selection.VISIBLE_TEXT) {
             setValueUsingVisibleText();
             return;
@@ -295,7 +291,12 @@ public class SelectEnhanced extends PageComponent {
 
     private void makeOptionSelected(WebElement option, String reason) {
         if (!option.isSelected()) {
-            AssertJUtil.assertThat(option.isEnabled()).as(reason).isTrue();
+            // Selenium allows disabled drop downs to still be set.
+            // So, to prevent this we will assert that the core element is enabled before setting the value
+            AssertJUtil.assertThat(isEnabled()).as("Select was disabled").isTrue();
+
+            // It is possible the core element was enabled but the option was disabled
+            AssertJUtil.assertThat(option).as(reason).isEnabled();
             option.click();
         }
     }


### PR DESCRIPTION
Move the validation of the core element being enabled to when clicking is necessary.  This will allow setting the data for a disabled drop down to be successful provided it is the default option which the user cannot change.  (Previously, the code would fail for this use case.)

**Note**:  Attempting to select any option other than the default from the disabled drop down will cause a failure as before but it will be slower as the assertion is at the end (instead of at the start.)