### PR TITLE
Fix Appium screenshot issue

### DIFF
--- a/taf/src/main/java/com/taf/automation/ui/support/util/ExpectedConditionsUtil.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/util/ExpectedConditionsUtil.java
@@ -455,8 +455,8 @@ public class ExpectedConditionsUtil {
 
                     Attachment jpeg = new Attachment()
                             .withTitle(title + append)
-                            .withType("image/jpeg")
-                            .withFile(ScreenshotUtil.convertPngToJpg(attachment));
+                            .withType(appium ? "image/png" : "image/jpeg")
+                            .withFile(appium ? attachment : ScreenshotUtil.convertPngToJpg(attachment));
                     screenshots.add(jpeg);
                     return screenshots;
                 } catch (Exception ex) {


### PR DESCRIPTION
It seems that for some unknown reason Appium returns a png that cannot be converted to jpg.  So, for Appium I have just attached the png to workaround the issue.