### PR TITLE
Update ui_auto_core to latest (2.6.1)

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/api/domainObjects/WeatherDO.java
+++ b/automation-tests/src/main/java/com/automation/common/api/domainObjects/WeatherDO.java
@@ -11,6 +11,7 @@ import com.taf.automation.ui.support.util.Helper;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamOmitField;
+import com.thoughtworks.xstream.security.AnyTypePermission;
 import org.apache.http.HttpEntity;
 import org.apache.http.NameValuePair;
 import org.apache.http.entity.StringEntity;
@@ -126,6 +127,7 @@ public class WeatherDO extends ApiDomainObject {
 
     public Weather getResponseWeather() {
         XStream xstream = getXstream();
+        xstream.addPermission(AnyTypePermission.ANY);
         xstream.alias("WeatherReturn", Weather.class);
         xstream.alias("soap:Envelope", Weather.class);
         xstream.registerConverter(new WeatherConverter());

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <selenium.version>3.141.59</selenium.version>
         <selenium.edge.version>3.141.0</selenium.edge.version>
         <appium.version>7.3.0</appium.version>
-        <ui.auto.core.version>2.5.21</ui.auto.core.version>
+        <ui.auto.core.version>2.6.1</ui.auto.core.version>
         <testNg.version>7.4.0</testNg.version>
         <hamcrest.version>1.3</hamcrest.version>
         <jetty-server.version>9.4.3.v20170317</jetty-server.version>

--- a/taf/src/main/java/com/taf/automation/api/ApiUtils.java
+++ b/taf/src/main/java/com/taf/automation/api/ApiUtils.java
@@ -6,6 +6,7 @@ import com.taf.automation.ui.support.util.AssertJUtil;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.xml.QNameMap;
 import com.thoughtworks.xstream.io.xml.StaxDriver;
+import com.thoughtworks.xstream.security.AnyTypePermission;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.http.HttpEntity;
@@ -408,6 +409,7 @@ public class ApiUtils {
         qmap.setDefaultPrefix("");
         StaxDriver staxDriver = new StaxDriver(qmap);
         XStream xstream = new XStream(staxDriver);
+        xstream.addPermission(AnyTypePermission.ANY);
         xstream.processAnnotations(apiDomainObject.getClass());
         return xstream;
     }

--- a/taf/src/main/java/com/taf/automation/api/clients/ApiClient.java
+++ b/taf/src/main/java/com/taf/automation/api/clients/ApiClient.java
@@ -12,6 +12,7 @@ import com.taf.automation.ui.support.TestProperties;
 import com.taf.automation.ui.support.util.CryptoUtils;
 import com.taf.automation.ui.support.util.URLUtils;
 import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.security.AnyTypePermission;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -369,6 +370,7 @@ public class ApiClient implements GenericHttpInterface {
     public XStream getRequestXStream() {
         if (requestXStream == null) {
             requestXStream = new XStream();
+            requestXStream.addPermission(AnyTypePermission.ANY);
         }
 
         return requestXStream;
@@ -381,6 +383,7 @@ public class ApiClient implements GenericHttpInterface {
     public XStream getResponseXStream() {
         if (responseXStream == null) {
             responseXStream = new XStream();
+            responseXStream.addPermission(AnyTypePermission.ANY);
         }
 
         return responseXStream;

--- a/taf/src/main/java/com/taf/automation/api/clients/XmlResponse.java
+++ b/taf/src/main/java/com/taf/automation/api/clients/XmlResponse.java
@@ -6,6 +6,7 @@ import com.taf.automation.api.rest.XmlBaseError;
 import com.taf.automation.api.rest.XmlError;
 import com.taf.automation.ui.support.TestProperties;
 import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.security.AnyTypePermission;
 import org.apache.http.Header;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -82,6 +83,7 @@ public class XmlResponse<T> implements GenericHttpResponse<T> {
     public XStream getXstream() {
         if (xstream == null) {
             xstream = new XStream();
+            xstream.addPermission(AnyTypePermission.ANY);
         }
 
         return xstream;

--- a/taf/src/main/java/com/taf/automation/api/rest/GenericHttpResponse.java
+++ b/taf/src/main/java/com/taf/automation/api/rest/GenericHttpResponse.java
@@ -1,6 +1,7 @@
 package com.taf.automation.api.rest;
 
 import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.security.AnyTypePermission;
 import org.apache.http.Header;
 import org.apache.http.StatusLine;
 
@@ -11,7 +12,9 @@ import org.apache.http.StatusLine;
  */
 public interface GenericHttpResponse<T> {
     default XStream getXstream() {
-        return new XStream();
+        XStream xstream = new XStream();
+        xstream.addPermission(AnyTypePermission.ANY);
+        return xstream;
     }
 
     /**

--- a/taf/src/main/java/com/taf/automation/asserts/CustomSoftAssertions.java
+++ b/taf/src/main/java/com/taf/automation/asserts/CustomSoftAssertions.java
@@ -3,6 +3,7 @@ package com.taf.automation.asserts;
 import com.taf.automation.ui.support.StringMod;
 import org.assertj.core.api.SoftAssertionError;
 import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.error.AssertionErrorCreator;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import ui.auto.core.pagecomponent.PageComponent;
@@ -70,7 +71,7 @@ public class CustomSoftAssertions extends SoftAssertions {
     public void assertAll() {
         List<Throwable> errors = errorsCollected();
         if (!errors.isEmpty()) {
-            tryThrowingMultipleFailuresError(errors);
+            new AssertionErrorCreator().tryThrowingMultipleFailuresError(errors);
             List<String> describeErrors = describeErrors(errors).stream()
                     .map(this::stripText)
                     .collect(Collectors.toList());
@@ -78,7 +79,7 @@ public class CustomSoftAssertions extends SoftAssertions {
         }
     }
 
-    private String stripText(String value){
+    private String stripText(String value) {
         return new StringMod(value)
                 .removeAll("at Helper.assertThatSubset\\(.*\\)\\r\\n")
                 .removeAll("at Helper.assertThatList\\(.*\\)\\r\\n")

--- a/taf/src/main/java/com/taf/automation/ui/support/DataPersistenceV2.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/DataPersistenceV2.java
@@ -5,6 +5,7 @@ import com.taf.automation.ui.support.util.DataInstillerUtils;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.annotations.XStreamOmitField;
 import com.thoughtworks.xstream.converters.extended.ISO8601GregorianCalendarConverter;
+import com.thoughtworks.xstream.security.AnyTypePermission;
 import datainstiller.data.DataGenerator;
 import datainstiller.data.DataPersistence;
 import org.apache.commons.jexl3.JexlContext;
@@ -70,6 +71,7 @@ public abstract class DataPersistenceV2 extends DataPersistence {
             xStream = DataInstillerUtils.getXStream(getJexlContext());
         }
 
+        xStream.addPermission(AnyTypePermission.ANY);
         xStream.processAnnotations(this.getClass());
         return xStream;
     }

--- a/taf/src/main/java/com/taf/automation/ui/support/DomainObject.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/DomainObject.java
@@ -7,6 +7,7 @@ import com.taf.automation.ui.support.util.CryptoUtils;
 import com.taf.automation.ui.support.util.DataInstillerUtils;
 import com.taf.automation.ui.support.util.Helper;
 import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.security.AnyTypePermission;
 import datainstiller.data.DataAliases;
 import datainstiller.data.DataPersistence;
 import org.apache.commons.jexl3.JexlContext;
@@ -50,6 +51,7 @@ public class DomainObject extends DomainObjectModel {
     @Override
     public XStream getXstream() {
         XStream xStream = DataInstillerUtils.getXStream(getJexlContext());
+        xStream.addPermission(AnyTypePermission.ANY);
         xStream.processAnnotations(this.getClass());
         return xStream;
     }

--- a/taf/src/main/java/com/taf/automation/ui/support/TestRunner.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/TestRunner.java
@@ -3,6 +3,7 @@ package com.taf.automation.ui.support;
 import com.taf.automation.ui.support.testng.TestParameterValidator;
 import com.taf.automation.ui.support.util.DownloadUtils;
 import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.security.AnyTypePermission;
 import io.qameta.allure.Commands;
 import io.qameta.allure.option.ConfigOptions;
 import net.lingala.zip4j.core.ZipFile;
@@ -157,6 +158,7 @@ public class TestRunner {
         Environment environment = new Environment().withName("Environment");
         environment.withParameter(prop.getAsParameters());
         XStream xstream = new XStream();
+        xstream.addPermission(AnyTypePermission.ANY);
         xstream.addImplicitArray(Environment.class, "parameter", "parameter");
         String xml = xstream.toXML(environment);
         xml = xml.replace("<ru.yandex.qatools.commons.model.Environment>", "<qa:environment xmlns:qa=\"urn:model.commons.qatools.yandex.ru\">");

--- a/taf/src/main/java/com/taf/automation/ui/support/util/DataInstillerUtils.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/util/DataInstillerUtils.java
@@ -10,6 +10,7 @@ import com.taf.automation.ui.support.generators.RandomDateGenerator;
 import com.taf.automation.ui.support.generators.RandomRealUSAddressGenerator;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.extended.ISO8601GregorianCalendarConverter;
+import com.thoughtworks.xstream.security.AnyTypePermission;
 import datainstiller.data.DataGenerator;
 import datainstiller.data.DataValueConverter;
 import datainstiller.generators.AddressGenerator;
@@ -122,6 +123,7 @@ public class DataInstillerUtils {
         addCustomGenerators(jexlContext);
         XStream xstream = new XStream();
 
+        xstream.addPermission(AnyTypePermission.ANY);
         xstream.registerConverter(new DataAliasesConverterV2(jexlContext, PageComponentContext.getGlobalAliases()));
         xstream.registerConverter(new ISO8601GregorianCalendarConverter());
 

--- a/taf/src/main/java/com/taf/automation/ui/support/util/Helper.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/util/Helper.java
@@ -1492,9 +1492,9 @@ public class Helper {
                     continue;
                 }
 
-                softly.assertThat(actualItem)
+                softly.assertThat(ApiUtils.readField(field, actualItem))
                         .as("%s[%s] - %s", type, i, name)
-                        .isEqualToComparingOnlyGivenFields(expectedItem, name);
+                        .isEqualTo(ApiUtils.readField(field, expectedItem));
             }
         }
     }

--- a/taf/src/main/java/com/taf/automation/ui/support/util/Helper.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/util/Helper.java
@@ -1590,9 +1590,9 @@ public class Helper {
                 continue;
             }
 
-            softly.assertThat(actual)
+            softly.assertThat(actual == null ? null : ApiUtils.readField(field, actual))
                     .as("%s - %s", type, name)
-                    .isEqualToComparingOnlyGivenFields(expected, name);
+                    .isEqualTo(ApiUtils.readField(field, expected));
         }
     }
 

--- a/taf/src/main/java/com/taf/automation/ui/support/util/Utils.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/util/Utils.java
@@ -9,6 +9,7 @@ import com.taf.automation.ui.support.WebDriverTypeEnum;
 import com.taf.automation.ui.support.testng.Attachment;
 import com.taf.automation.ui.support.testng.TestNGBase;
 import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.security.AnyTypePermission;
 import datainstiller.data.DataPersistence;
 import net.jodah.failsafe.ExecutionContext;
 import net.jodah.failsafe.Failsafe;
@@ -663,6 +664,7 @@ public class Utils {
     @SuppressWarnings("unchecked")
     public static <T> T deepCopy(T obj) {
         XStream xstream = new XStream();
+        xstream.addPermission(AnyTypePermission.ANY);
         String xml = xstream.toXML(obj);
         return (T) xstream.fromXML(xml);
     }


### PR DESCRIPTION
There were the following issues that appeared when upgrading:
- XStream was throwing "com.thoughtworks.xstream.security.ForbiddenClassException" due to it now denying permissions by default on unknown classes.  Since, it does not make sense to whitelist classes for automation I set it to accept all unknown classes (which is how it worked in the previous versions.)
- AssertJ moved tryThrowingMultipleFailuresError to a another class.
- AssertJ deprecated isEqualToComparingOnlyGivenFields.  It was necessary to re-factor the Helper methods that used this assertion.