### PR TITLE
Add method to check if the substitutions are empty

### DIFF
--- a/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/HerokuappDataTable1Page.java
+++ b/automation-tests/src/main/java/com/automation/common/ui/app/pageObjects/HerokuappDataTable1Page.java
@@ -16,6 +16,7 @@ import java.util.Map;
 @SuppressWarnings({"squid:MaximumInheritanceDepth", "java:S3252"})
 public class HerokuappDataTable1Page extends GenericTable<HerokuappRowTable1> {
     private static final By TABLE1_ROWS = By.cssSelector("#table1 tbody tr");
+    private Map<String, String> substitutions;
 
     public HerokuappDataTable1Page() {
         super();
@@ -42,9 +43,13 @@ public class HerokuappDataTable1Page extends GenericTable<HerokuappRowTable1> {
 
     @Override
     protected Map<String, String> getSubstitutions() {
-        HerokuappColumnPositionsExtractor extractor = new HerokuappColumnPositionsExtractor();
-        Map<String, String> columnPositions = extractor.getMap();
-        return extractor.getSubstitutions(HerokuappColumnMapping.LAST_NAME, columnPositions);
+        if (substitutions == null) {
+            HerokuappColumnPositionsExtractor extractor = new HerokuappColumnPositionsExtractor();
+            Map<String, String> columnPositions = extractor.getMap();
+            substitutions = extractor.getSubstitutions(HerokuappColumnMapping.LAST_NAME, columnPositions);
+        }
+
+        return substitutions;
     }
 
     @Override

--- a/taf/src/main/java/com/taf/automation/ui/support/GenericTable.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/GenericTable.java
@@ -364,6 +364,13 @@ public abstract class GenericTable<T extends GenericRow> extends PageObjectV2 {
     }
 
     /**
+     * @return true if the substitutions are empty else false
+     */
+    public boolean isEmptySubstitutions() {
+        return getSubstitutions().isEmpty();
+    }
+
+    /**
      * Get a locator that should find all rows in the table <BR>
      * If NULL is returned, criteria looking for this will skip it without waiting for timeout
      *


### PR DESCRIPTION
This is only needed if you have nested tables (or dynamic page with a table.)

The table class would need something similar to the following:
```
    public void updateRowKey(String value) {
        AssertJUtil.assertThat(value).as("Row Key").isNotBlank();
        getSubstitutions().put(CUSTOM_ROW_KEY, value);
    }

    public void updateRowKey(Map<String, String> substitutions) {
        updateRowKey(substitutions.get(DEFAULT_ROW_KEY));
    }

    @Override
    protected Map<String, String> getSubstitutions() {
        if (substitutions == null) {
            substitutions = new HashMap<>();
        }

        return substitutions;
    }
```
The getter for the table would be similar to the following:
```
    public SomeTable getSomeTable() {
        if (someTable == null) {
            someTable = new SomeTable();
        }

        if (someTable.getContext() == null || someTable.isEmptySubstitutions()) {
            // At this point, the substitutions from the dynamic page (or table) has the key(s) to initial this table
            someTable.updateRowKey(getSubstitutions());
            someTable.initPage(getContext());
        }

        return someTable;
    }
```