### PR TITLE
Add random remote debugging port for Chrome

### DIFF
--- a/taf/src/main/java/com/taf/automation/ui/support/WebDriverTypeEnum.java
+++ b/taf/src/main/java/com/taf/automation/ui/support/WebDriverTypeEnum.java
@@ -17,6 +17,7 @@ import org.openqa.selenium.firefox.FirefoxDriverLogLevel;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.ie.InternetExplorerDriver;
+import org.openqa.selenium.net.PortProber;
 import org.openqa.selenium.opera.OperaDriver;
 import org.openqa.selenium.remote.Browser;
 import org.openqa.selenium.remote.BrowserType;
@@ -237,6 +238,7 @@ public enum WebDriverTypeEnum {
         chromeOptions.addArguments("--ignore-certificate-errors");
         chromeOptions.addArguments("--disable-gpu");
         chromeOptions.addArguments("--dns-prefetch-disable");
+        chromeOptions.addArguments("--remote-debugging-port=" + PortProber.findFreePort());
 
         if (prop.getUserAgent() != null) {
             chromeOptions.addArguments("user-agent=" + prop.getUserAgent());


### PR DESCRIPTION
Chrome on Linux was throwing:
```
Caused by: org.openqa.selenium.SessionNotCreatedException: Could not start a new session. Response code 500. 
Message: unknown error: DevToolsActivePort file doesn't exist
```
I suspect this is related to it being a snap on Ubuntu.  After some research and testing, I found that adding "--remote-debugging-port=9222" resolved the issue.  However, using the same port for multiple chrome instances when running tests in parallel caused other issues which seem related to using the same port.  I changed to always using a different port and the issues were resolved.