### PR TITLE
Updates for Java 11 support/migration

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
         java-version: 1.8

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,9 +16,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 16
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Build with Maven
       run: mvn -B clean package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 16
       uses: actions/setup-java@v1
       with:
         java-version: 1.8

--- a/automation-tests/pom.xml
+++ b/automation-tests/pom.xml
@@ -48,7 +48,7 @@
             </plugin>
             -->
             <plugin>
-                <groupId>com.nickwongdev</groupId>
+                <groupId>dev.aspectj</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
                 <version>${aspectj.maven.plugin.version}</version>
                 <configuration>
@@ -105,21 +105,6 @@
     </build>
 
     <dependencies>
-        <dependency>
-            <groupId>org.aspectj</groupId>
-            <artifactId>aspectjrt</artifactId>
-            <version>${aspectj.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>ru.yandex.qatools.allure</groupId>
-            <artifactId>allure-java-aspects</artifactId>
-            <version>${allure.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <version>${testNg.version}</version>
-        </dependency>
         <dependency>
             <groupId>com.automation</groupId>
             <artifactId>taf</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,10 +16,15 @@
     </modules>
 
     <properties>
+        <!-- Java 8 -->
         <compiler.version>1.8</compiler.version>
+
+        <!-- Java 11 -->
+        <!-- <compiler.version>11</compiler.version> -->
+
         <allure.version>1.4.19</allure.version>
-        <aspectj.maven.plugin.version>1.12.1</aspectj.maven.plugin.version>
-        <aspectj.version>1.9.2</aspectj.version>
+        <aspectj.maven.plugin.version>1.13.1</aspectj.maven.plugin.version>
+        <aspectj.version>1.9.9.1</aspectj.version>
         <maven-compiler-plugin>3.8.1</maven-compiler-plugin>
         <maven-assembly-plugin>3.3.0</maven-assembly-plugin>
         <guava.version>31.1-jre</guava.version>
@@ -35,13 +40,13 @@
         <jsoup.version>1.13.1</jsoup.version>
         <jsch.version>0.1.53</jsch.version>
         <failsafe.version>2.3.4</failsafe.version>
-        <springframework.version>4.2.4.RELEASE</springframework.version>
-        <mysql-connector.version>5.1.38</mysql-connector.version>
+        <springframework.version>5.3.20</springframework.version>
+        <mysql-connector.version>8.0.29</mysql-connector.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <httpclient.version>4.5.12</httpclient.version>
         <pdfbox.version>1.8.2</pdfbox.version>
         <vtd.version>2.11</vtd.version>
-        <jackson.version>2.9.8</jackson.version>
+        <jackson.version>2.13.3</jackson.version>
         <apache.commons.version>3.11</apache.commons.version>
         <apache.commons.text.version>1.3</apache.commons.text.version>
         <findbugs.version>3.0.1</findbugs.version>
@@ -49,7 +54,7 @@
         <browser.mob.proxy.version>2.1.5</browser.mob.proxy.version>
         <httpmime.version>4.5.12</httpmime.version>
         <axe.selenium.version>2.0</axe.selenium.version>
-        <sql.server.version>6.4.0.jre8</sql.server.version>
+        <sql.server.version>10.2.1.jre17</sql.server.version>
         <cucumber.version>1.2.5</cucumber.version>
         <allure.cucumber.version>1.6.4</allure.cucumber.version>
         <allure.properties.loader.version>1.5</allure.properties.loader.version>
@@ -64,7 +69,9 @@
         <jaxb.api.version>2.3.1</jaxb.api.version>
         <jaxb.core.version>2.3.0.1</jaxb.core.version>
         <jaxb.impl.version>2.3.1</jaxb.impl.version>
+        <glassfish.jaxb.version>2.3.1</glassfish.jaxb.version>
         <jollyday.version>0.5.8</jollyday.version>
+        <dom4j.version>2.1.3</dom4j.version>
     </properties>
 
     <build>

--- a/taf/pom.xml
+++ b/taf/pom.xml
@@ -16,7 +16,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.nickwongdev</groupId>
+                <groupId>dev.aspectj</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
                 <version>${aspectj.maven.plugin.version}</version>
                 <configuration>
@@ -270,9 +270,20 @@
             <version>${jaxb.impl.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>${glassfish.jaxb.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>de.jollyday</groupId>
             <artifactId>jollyday</artifactId>
             <version>${jollyday.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.dom4j</groupId>
+            <artifactId>dom4j</artifactId>
+            <version>${dom4j.version}</version>
         </dependency>
         <!-- START:  BDD specific dependencies -->
         <dependency>

--- a/taf/src/main/java/com/taf/automation/api/ApiUtils.java
+++ b/taf/src/main/java/com/taf/automation/api/ApiUtils.java
@@ -17,17 +17,12 @@ import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BasicStatusLine;
-import org.xml.sax.InputSource;
+import org.dom4j.DocumentHelper;
+import org.dom4j.io.OutputFormat;
+import org.dom4j.io.XMLWriter;
 
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Source;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.sax.SAXSource;
-import javax.xml.transform.sax.SAXTransformerFactory;
-import javax.xml.transform.stream.StreamResult;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.StringWriter;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -57,16 +52,14 @@ public class ApiUtils {
     @SuppressWarnings({"java:S2755", "java:S3252"})
     public static String prettifyXML(String inXML) {
         try {
-            Transformer trans = SAXTransformerFactory.newInstance().newTransformer();
-            trans.setOutputProperty(OutputKeys.INDENT, "yes");
-            trans.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
-            Source xmlSource = new SAXSource(new InputSource(new ByteArrayInputStream(inXML.getBytes())));
-            StreamResult sRes = new StreamResult(new ByteArrayOutputStream());
-            trans.transform(xmlSource, sRes);
-            String xmlOut = new String(((ByteArrayOutputStream) sRes.getOutputStream()).toByteArray());
-            xmlOut = xmlOut.replace("\"UTF-8\"?><", "\"UTF-8\"?>\n<");
-            xmlOut = xmlOut.replace(" xmlns:", "\n xmlns:");
-            return xmlOut;
+            OutputFormat format = OutputFormat.createPrettyPrint();
+            format.setSuppressDeclaration(false);
+
+            org.dom4j.Document document = DocumentHelper.parseText(inXML);
+            StringWriter sw = new StringWriter();
+            XMLWriter writer = new XMLWriter(sw, format);
+            writer.write(document);
+            return sw.toString();
         } catch (Exception e) {
             return inXML;
         }


### PR DESCRIPTION
There were a few issues with Java 11 or higher:
- The package org.xml.sax is accessible from more than one module: <unnamed>, java.xml
- Implementation of JAXB-API has not been found on module path or classpath.

The ApiUtils class had the "package * is accessible form more than one module" issue.  I was unable to resolve this using any of the solutions provided by people that had a similar issue.  The only way to resolve it was to use dom4j instead of the standard java libraries.

The next error occurred on at runtime when trying to create the Allure report.  It seems that the implementation of JAXB-API was removed from Java in 11.  So, it was necessary to use the glassfish implementation to resolve the error.

**Note**:  The libraries were upgraded to try and resolve the initial "package * is accessible form more than one module" issue.  The libraries don't really need to be updated but since they are working fine I left them.